### PR TITLE
Add test-gated CI deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,94 @@
+name: Test and Deploy CEDAR
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.gitignore'
+  workflow_dispatch:
+
+concurrency:
+  group: cedar-production-deploy
+  cancel-in-progress: true
+
+jobs:
+  # Gate: build the same image production runs, and run the full test suite
+  # inside it. Docker is the reproducibility layer (no renv in the image), so
+  # testing inside the image validates the exact artifact being shipped.
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (same Dockerfile as production)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.shiny
+          load: true
+          tags: cedar:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run test suite inside the image
+        run: |
+          docker run --rm --user root --entrypoint Rscript cedar:ci \
+            -e "install.packages('testthat')" \
+            -e "setwd('/srv/shiny-server/cedar'); testthat::test_dir('tests/testthat', stop_on_failure = TRUE)"
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Deploy over SSH
+        # Third-party action with access to the deploy key — pinned to the
+        # commit SHA of v1.2.0 so a moved tag can't change what runs.
+        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USER }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script_stop: true
+          # The droplet builds the image itself; allow more than the 10m default.
+          command_timeout: 30m
+          script: |
+            set -e
+
+            cd "${{ secrets.CEDAR_PATH }}"
+
+            git fetch --prune origin main
+            git checkout main
+            git reset --hard origin/main
+
+            docker compose up -d --build --remove-orphans
+            docker compose ps
+
+            # Health check: compose reports success as soon as the container
+            # starts, but the app isn't up until shiny-server serves the page
+            # (and the first real request triggers the heavy global.R data
+            # load). Poll for up to 5 minutes before calling the deploy good.
+            echo "Waiting for app to respond at http://localhost:3838/cedar/ ..."
+            for i in $(seq 1 60); do
+              if curl -fsS -o /dev/null --max-time 20 http://localhost:3838/cedar/; then
+                echo "Health check passed on attempt $i."
+                exit 0
+              fi
+              sleep 5
+            done
+
+            echo "Health check FAILED after 5 minutes. Recent container logs:"
+            docker compose logs --tail 100 cedar-shiny
+            exit 1


### PR DESCRIPTION
## What changed

Commits the previously untracked `deploy.yml` (it was inert — workflows only run once they exist in the repo on GitHub) with the hardening discussed:

- **Test gate.** A `test` job builds the production image (`Dockerfile.shiny`, buildx with GitHub Actions layer cache) and runs the full testthat suite *inside* it; `deploy` requires it via `needs: test`. Since Docker is the project's reproducibility layer (no renv in the image), this validates the exact artifact being shipped — and sidesteps the chronically fragile local renv entirely. `testthat` is installed at test time from Posit's binary repo (it's not in the production image, deliberately).
- **Docs-only pushes don't deploy.** `paths-ignore` for markdown, `docs/`, and `.gitignore` — merging something like the recent docs-consolidation PR no longer triggers a production rebuild.
- **Post-deploy health check.** `docker compose up -d` reports success at container start, before shiny-server actually serves anything. The script now polls `http://localhost:3838/cedar/` for up to 5 minutes and dumps the last 100 container log lines if the app never comes up, so a startup crash turns the Action red instead of silently shipping a dead app.
- **Supply-chain pin.** `appleboy/ssh-action` (a third-party action holding the deploy key) is pinned to the commit SHA of v1.2.0 rather than the mutable tag. `command_timeout` raised to 30m since the droplet builds the image itself.

## Before merging

1. **Repo secrets must exist:** `DROPLET_HOST`, `DROPLET_USER`, `DROPLET_SSH_KEY`, `CEDAR_PATH`. The deploy job will fail (harmlessly) without them.
2. **Merging this PR triggers the workflow** — the paths filter doesn't exclude workflow files. Expect the first `test` run to take a while (cold image build, ~10–15 min; cached after), then a deploy attempt.
3. The test-in-container command mirrors the documented local invocation (`testthat::test_dir('tests/testthat')` from the project root; suite currently passes 1720/0), but the first CI run is its first execution in this exact form — if it needs a tweak, it will show up immediately and the deploy gate will hold.

## Deliberately not done (future upgrade path)

Building on the droplet means production absorbs build load and Docker-disk pressure. The eventual upgrade is building in CI, pushing to GHCR, and having the droplet pull — not worth the complexity at current scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
