### PR TITLE
Serve CEDAR app at the domain root, not the /cedar subpath

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,9 +79,9 @@ jobs:
             # starts, but the app isn't up until shiny-server serves the page
             # (and the first real request triggers the heavy global.R data
             # load). Poll for up to 5 minutes before calling the deploy good.
-            echo "Waiting for app to respond at http://localhost:3838/cedar/ ..."
+            echo "Waiting for app to respond at http://localhost:3838/ ..."
             for i in $(seq 1 60); do
-              if curl -fsS -o /dev/null --max-time 20 http://localhost:3838/cedar/; then
+              if curl -fsS -o /dev/null --max-time 20 http://localhost:3838/; then
                 echo "Health check passed on attempt $i."
                 exit 0
               fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -640,7 +640,7 @@ sub-tabs, reactable DOM selectors + uppercased headers). Keep ad-hoc check scrip
 in `tests/e2e/` while iterating, then delete them.
 
 Notes:
-- The app runs in Docker at `http://localhost:3838/cedar/` (source is baked via
+- The app runs in Docker at `http://localhost:3838/` (source is baked via
   `COPY . .`, so **code changes need a rebuild** — `rebuild-and-test.sh`; only the
   `COPY` layer re-runs, so it's fast after the first cold build). Data is mounted
   from `CEDAR_DATA_DIR` (`.env`).

--- a/rebuild-and-test.sh
+++ b/rebuild-and-test.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-URL="http://localhost:3838/cedar/"
+URL="http://localhost:3838/"
 
 echo "[rebuild] building image + (re)starting container…"
 docker compose up -d --build

--- a/scripts/restart-cedar.sh
+++ b/scripts/restart-cedar.sh
@@ -80,7 +80,7 @@ Shared options:
 Env overrides (same as update-data.sh):
   PROD_CEDAR_REPO, PROD_DOCKER_COMPOSE_FILE, PROD_CONTAINER_NAME, PROD_APP_URL
   LOCAL_CONTAINER_NAME (default: cedar-shiny)
-  LOCAL_APP_URL        (default: http://localhost:3838/cedar/)
+  LOCAL_APP_URL        (default: http://localhost:3838/)
 
 Examples:
   $(basename "$0")                                      # Restart only (default)
@@ -107,7 +107,7 @@ PROD_CEDAR_REPO="${PROD_CEDAR_REPO:-/root/cedar}"
 PROD_DOCKER_COMPOSE_FILE="${PROD_DOCKER_COMPOSE_FILE:-$PROD_CEDAR_REPO/docker-compose.yml}"
 PROD_MRGATHER_DIR="${PROD_MRGATHER_DIR:-/root/mrgather}"
 PROD_CONTAINER_NAME="${PROD_CONTAINER_NAME:-cedar-shiny}"
-PROD_APP_URL="${PROD_APP_URL:-http://localhost:3838/cedar/}"
+PROD_APP_URL="${PROD_APP_URL:-http://localhost:3838/}"
 CEDAR_CONTAINER_DIR="${CEDAR_CONTAINER_DIR:-/srv/shiny-server/cedar}"
 
 # ── Parse args ─────────────────────────────────────────────────────────────────
@@ -162,7 +162,7 @@ else
     CEDAR_HOST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
     DOCKER_COMPOSE_FILE="$CEDAR_HOST_DIR/docker-compose.yml"
     CONTAINER_NAME="${LOCAL_CONTAINER_NAME:-cedar-shiny}"
-    APP_URL="${LOCAL_APP_URL:-http://localhost:3838/cedar/}"
+    APP_URL="${LOCAL_APP_URL:-http://localhost:3838/}"
     DOCKER_CMD="docker"
 fi
 

--- a/scripts/update-data.sh
+++ b/scripts/update-data.sh
@@ -129,7 +129,7 @@ Optional:
     PROD_MRGATHER_COMPOSE_FILE (default: /root/mrgather/docker-compose.yml)
     PROD_SHARED_DATA_DIR       (default: /root/shared-data)
     PROD_CONTAINER_NAME        (default: cedar-shiny)
-    PROD_APP_URL               (default: http://localhost:3838/cedar/)
+    PROD_APP_URL               (default: http://localhost:3838/)
 
   -h               Show this help message
   REPORTS          Space-separated list of reports to fetch (default: all)
@@ -159,7 +159,7 @@ PROD_MRGATHER_DIR="${PROD_MRGATHER_DIR:-/root/mrgather}"
 PROD_MRGATHER_COMPOSE_FILE="${PROD_MRGATHER_COMPOSE_FILE:-$PROD_MRGATHER_DIR/docker-compose.yml}"
 PROD_SHARED_DATA_DIR="${PROD_SHARED_DATA_DIR:-/root/shared-data}"
 PROD_CONTAINER_NAME="${PROD_CONTAINER_NAME:-cedar-shiny}"
-PROD_APP_URL="${PROD_APP_URL:-http://localhost:3838/cedar/}"
+PROD_APP_URL="${PROD_APP_URL:-http://localhost:3838/}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in

--- a/shiny-server.conf
+++ b/shiny-server.conf
@@ -7,10 +7,11 @@ server {
   app_init_timeout 500;
   app_idle_timeout 0;
   
-  # You can add other config here as needed
+  # Serve the single CEDAR app at the domain root (app_dir), not as a
+  # /cedar subpath (site_dir). The nginx proxy forwards unm.cedarplatform.org/
+  # straight to this backend, so the app must live at "/" for a clean URL.
   location / {
-    site_dir /srv/shiny-server;
+    app_dir /srv/shiny-server/cedar;
     log_dir /var/log/shiny-server;
-    directory_index on;
   }
 }

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,7 +1,7 @@
 # E2E browser checks (dockerized app)
 
 Headless-browser checks that drive the **running** CEDAR app at
-`http://localhost:3838/cedar/`. They use `puppeteer-core` against the system
+`http://localhost:3838/`. They use `puppeteer-core` against the system
 Chrome (`/Applications/Google Chrome.app`) — no browser is downloaded.
 
 ## One-time setup

--- a/tests/e2e/lib.mjs
+++ b/tests/e2e/lib.mjs
@@ -3,7 +3,7 @@
 // Import these instead of re-deriving the connect/setInput/click/read boilerplate
 // in every script. See README.md → "Driving inputs and reading output back" for a
 // copy-paste recipe. All helpers run against the dockerized app at
-// http://localhost:3838/cedar/ (override with CEDAR_URL).
+// http://localhost:3838/ (override with CEDAR_URL).
 //
 //   import { launch, connect, setInput, click, clickNavTab, clickSubTab,
 //            waitForSelector, readReactable, colIndex, sleep } from './lib.mjs';
@@ -11,7 +11,7 @@ import puppeteer from 'puppeteer-core';
 
 export const CHROME = process.env.CHROME_PATH ||
   '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-export const BASE = process.env.CEDAR_URL || 'http://localhost:3838/cedar/';
+export const BASE = process.env.CEDAR_URL || 'http://localhost:3838/';
 
 export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 

--- a/tests/e2e/nav.test.mjs
+++ b/tests/e2e/nav.test.mjs
@@ -1,5 +1,5 @@
 // Headless E2E checks for the top-nav URL routing in the running CEDAR app.
-// Drives the dockerized app (http://localhost:3838/cedar/) with system Chrome.
+// Drives the dockerized app (http://localhost:3838/) with system Chrome.
 //
 //   node tests/e2e/nav.test.mjs
 //
@@ -10,7 +10,7 @@
 import puppeteer from 'puppeteer-core';
 
 const CHROME = process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-const BASE = process.env.CEDAR_URL || 'http://localhost:3838/cedar/';
+const BASE = process.env.CEDAR_URL || 'http://localhost:3838/';
 
 const results = [];
 let failed = 0;

--- a/tests/test-docker-shiny.sh
+++ b/tests/test-docker-shiny.sh
@@ -38,7 +38,7 @@ DO_BUILD=true
 FOLLOW_LOGS=false
 CHECK_URL=false
 TIMEOUT=45
-APP_URL="http://localhost:3838/cedar/"
+APP_URL="http://localhost:3838/"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Problem

`unm.cedarplatform.org/` (bare domain) landed on shiny-server's default page instead of the app; the app was only reachable at `/cedar`. This started after the first automated deploy synced the running container to current source.

Root cause: the nginx proxy on the droplet forwards the bare domain root straight through to the shiny backend (`location / → cedar-shiny:3838/`), unchanged for months. But `shiny-server.conf` used `site_dir /srv/shiny-server`, which serves the app at the `/cedar` subpath (the app dir is `/srv/shiny-server/cedar`). The previously-running container served the app at root; the fresh deploy brought it in line with the repo, moving it to `/cedar`. No config was edited to cause this — the deploy just made the repo's existing layout take effect.

## Fix

Switch `shiny-server.conf` from `site_dir` to `app_dir /srv/shiny-server/cedar`, so the single app is served at `/`. The nginx proxy then reaches it exactly as before — no nginx change needed.

Because the mount point moved from `/cedar/` to `/`, everything that hardcoded the subpath follows:

- **`deploy.yml`** health check now curls `http://localhost:3838/` instead of `/cedar/`. Without this the deploy's own health check would 404 and fail the deploy.
- **e2e harness** (`tests/e2e/lib.mjs`, `nav.test.mjs`) `BASE` default, **ops scripts** (`rebuild-and-test.sh`, `scripts/restart-cedar.sh`, `scripts/update-data.sh`, `tests/test-docker-shiny.sh`) `APP_URL`/`PROD_APP_URL` defaults, and **docs** (`AGENTS.md`, `tests/e2e/README.md`) updated from `http://localhost:3838/cedar/` to `http://localhost:3838/`. All remain overridable via `CEDAR_URL` / env.

## Verification

Built the image and ran it locally with the data dir mounted:

- `/` serves the CEDAR app — `<title>CEDAR</title>`, no "Welcome to Shiny Server" default page.
- `/?tab=home` (the app's internal routing) returns 200.
- `/cedar/` now correctly returns 404.

After this merges and deploys, `https://unm.cedarplatform.org/` will serve the app directly with a clean URL, matching the prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
