### PR TITLE
Unify the default term across the registration-facing tabs

### DIFF
--- a/R/modules/cancellations.R
+++ b/R/modules/cancellations.R
@@ -3,10 +3,10 @@
 # Shows cancelled course sections and cancellation timing patterns.
 #
 # Exported functions:
-#   cancellationsUI(id, sections, next_term, dept_choices)
+#   cancellationsUI(id, sections, default_term, dept_choices)
 #   cancellationsServer(id, sections, error_handler = NULL)
 
-cancellationsUI <- function(id, sections, next_term, dept_choices) {
+cancellationsUI <- function(id, sections, default_term, dept_choices) {
   ns <- NS(id)
   tagList(
     filter_bar(
@@ -29,7 +29,7 @@ cancellationsUI <- function(id, sections, next_term, dept_choices) {
         column(2,
           selectizeInput(ns("cn_term"), "Term", multiple = TRUE,
                          choices = sort(unique(c(sections$term_type, sections$term)), decreasing = TRUE),
-                         selected = next_term)
+                         selected = default_term)
         ),
         column(1,
           selectInput(ns("cn_pt"), "PoT", multiple = TRUE,

--- a/R/modules/regstats.R
+++ b/R/modules/regstats.R
@@ -1,4 +1,4 @@
-regstatsUI <- function(id, sections, thresholds, dept_choices, current_term = NULL) {
+regstatsUI <- function(id, sections, thresholds, dept_choices, default_term = NULL) {
   ns <- NS(id)
 
   tagList(
@@ -22,7 +22,7 @@ regstatsUI <- function(id, sections, thresholds, dept_choices, current_term = NU
         column(2,
           selectInput(ns("rs_term"), "Term", multiple = TRUE,
             choices  = sort(unique(c(sections$term_type, sections$term)), decreasing = TRUE),
-            selected = if (!is.null(current_term)) as.character(add_term(current_term)) else NULL)
+            selected = if (!is.null(default_term)) as.character(default_term) else NULL)
         ),
         column(2,
           selectInput(ns("rs_level"), "Level", multiple = TRUE,

--- a/R/modules/seatfinder.R
+++ b/R/modules/seatfinder.R
@@ -3,10 +3,10 @@
 # Shows courses with available capacity for selected filters, with DFW history.
 #
 # Exported functions:
-#   seatfinderUI(id, sections, next_term, dept_choices)
+#   seatfinderUI(id, sections, default_term, dept_choices)
 #   seatfinderServer(id, students, sections, faculty)
 
-seatfinderUI <- function(id, sections, next_term, dept_choices) {
+seatfinderUI <- function(id, sections, default_term, dept_choices) {
   ns <- NS(id)
   tagList(
     filter_bar(
@@ -29,7 +29,7 @@ seatfinderUI <- function(id, sections, next_term, dept_choices) {
         column(2,
           selectizeInput(ns("sf_term"), "Term", multiple = TRUE,
                          choices = sort(unique(c(sections$term_type, sections$term)), decreasing = TRUE),
-                         selected = next_term)
+                         selected = default_term)
         ),
         column(1,
           selectInput(ns("sf_pt"), "PoT", multiple = TRUE,

--- a/R/modules/waitlist.R
+++ b/R/modules/waitlist.R
@@ -4,14 +4,14 @@
 # Also handles cross-tab navigation from regstats via the wl_navigate input.
 #
 # Exported functions:
-#   waitlistUI(id, sections, next_term, dept_choices)
+#   waitlistUI(id, sections, default_term, dept_choices)
 #   waitlistServer(id, students, parent_session)
 #
 # Cross-tab note: the regstats tab triggers navigation here via
 # Shiny.setInputValue('waitlist-wl_navigate', ...) — the namespace prefix is
 # required because wl_navigate lives inside this module.
 
-waitlistUI <- function(id, sections, next_term, dept_choices) {
+waitlistUI <- function(id, sections, default_term, dept_choices) {
   ns <- NS(id)
   tagList(
     filter_bar(
@@ -41,7 +41,7 @@ waitlistUI <- function(id, sections, next_term, dept_choices) {
         column(2,
           selectizeInput(ns("wl_term"), "Term", multiple = TRUE,
                          choices = sort(unique(c(sections$term_type, sections$term)), decreasing = TRUE),
-                         selected = next_term)
+                         selected = default_term)
         ),
         column(1,
           selectInput(ns("wl_pt"), "PoT", multiple = TRUE,

--- a/R/trunk/utils.R
+++ b/R/trunk/utils.R
@@ -215,6 +215,49 @@ add_term <- function (term_code,summer=F) {
 }
 
 
+# Default term for the registration-facing tabs (Open Seats, Waitlists,
+# Cancellations, Regstats). These all want to open on the same term so users
+# don't have to re-pick it per tab.
+#
+# Until registration for the next term is actually underway, they default to
+# the current term: a schedule can be built (and its sections loaded) months
+# before registration opens, so defaulting to next term early would present
+# preliminary, half-built data as if it were real. `registration_underway` is
+# the manual switch (cedar_registration_underway) the admin flips once
+# registration opens.
+#
+# The only ambiguous step is Spring -> (Summer vs Fall): both open for
+# registration at the same time in the spring. Summer is the default until
+# summer registration effectively closes in mid-June (`summer_cutoff`), after
+# which Fall becomes the default. Every other step (Summer -> Fall,
+# Fall -> next Spring) is unambiguous.
+#
+# summer_cutoff is an "MM-DD" string; the comparison year comes from the term
+# being registered for, not the wall clock, so stale config degrades sanely.
+get_default_reg_term <- function(current_term,
+                                 registration_underway,
+                                 today = Sys.Date(),
+                                 summer_cutoff = "06-15") {
+  current_term <- as.integer(current_term)
+  if (!isTRUE(registration_underway)) return(current_term)
+
+  season <- current_term %% 100L
+
+  if (season == 10L) {                              # Spring: Summer and Fall both open
+    term_year <- current_term %/% 100L
+    cutoff    <- as.Date(sprintf("%d-%s", term_year, summer_cutoff))
+    if (today > cutoff) {
+      return(add_term(current_term))                # Spring -> Fall (skips summer)
+    }
+    return(add_term(current_term, summer = TRUE))   # Spring -> Summer
+  }
+
+  # Summer -> Fall and Fall -> next Spring: keep the summer link so Summer
+  # advances to Fall rather than being skipped.
+  add_term(current_term, summer = TRUE)
+}
+
+
 add_term_type_col <- function(df, term_col_name) {
   message("adding term type col...")
   term_col <- rlang::ensym(term_col_name)

--- a/config/config_template.R
+++ b/config/config_template.R
@@ -28,7 +28,13 @@ cedar_current_term <- 202510
 cedar_report_start_term <- 201980
 cedar_report_end_term <- 202510
 
-# registration underway for next term (compared to current term set above)
+# Has registration for the next term actually opened (compared to the current
+# term set above)? Drives the default term on the registration-facing tabs
+# (Open Seats, Waitlists, Cancellations, Regstats): FALSE = default to the
+# current term; TRUE = default to the next term students are registering for.
+# Leave FALSE until registration truly opens so preliminary schedule builds
+# don't present half-built next-term data as if it were real. In spring the
+# next term is Summer until mid-June, then Fall (see get_default_reg_term()).
 cedar_registration_underway <- FALSE
 
 ########### Thresholds for various reports

--- a/config/shiny_config_template.R
+++ b/config/shiny_config_template.R
@@ -18,7 +18,13 @@ cedar_current_term <- 202610
 cedar_report_start_term <- 202180
 cedar_report_end_term <- 202560
 
-# registration underway for next term (compared to current term set above)
+# Has registration for the next term actually opened (compared to the current
+# term set above)? Drives the default term on the registration-facing tabs
+# (Open Seats, Waitlists, Cancellations, Regstats): FALSE = default to the
+# current term; TRUE = default to the next term students are registering for.
+# Leave FALSE until registration truly opens so preliminary schedule builds
+# don't present half-built next-term data as if it were real. In spring the
+# next term is Summer until mid-June, then Fall (see get_default_reg_term()).
 cedar_registration_underway <- FALSE
 
 # Minimum group size for descriptive breakdowns (small-cell suppression).

--- a/global.R
+++ b/global.R
@@ -520,12 +520,13 @@ cedar_current_term_label <- local({
   paste0(season, " ", yr)
 })
 
-# First term in the data strictly after the current configured term (used for UI defaults)
-cedar_next_term <- local({
-  terms <- as.integer(unique(data_objects[["cedar_sections"]]$term))
-  future <- terms[terms > as.integer(cedar_current_term)]
-  if (length(future) > 0) as.character(min(future)) else as.character(cedar_current_term)
-})
+# Shared default term for the registration-facing tabs (Open Seats, Waitlists,
+# Cancellations, Regstats). Current term until cedar_registration_underway is
+# flipped on; then the next term students are registering for, with the
+# Spring->Summer/Fall cutover handled by date. See get_default_reg_term().
+cedar_default_reg_term <- as.character(
+  get_default_reg_term(cedar_current_term, cedar_registration_underway)
+)
 
 # Pathways population selectors use small choice lists derived from the large
 # cedar_programs table. Build them once at startup so each browser session does

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -39,6 +39,30 @@ test_that("single term arithmetic functions behave", {
   expect_equal(add_term("202360", summer = TRUE), 202380)
 })
 
+test_that("get_default_reg_term returns the current term until registration is underway", {
+  # Flag off: always the current term, regardless of date.
+  expect_equal(get_default_reg_term(202610, FALSE, today = as.Date("2026-07-10")), 202610)
+  expect_equal(get_default_reg_term(202680, FALSE, today = as.Date("2026-11-01")), 202680)
+})
+
+test_that("get_default_reg_term resolves the next registration term when underway", {
+  # Spring: Summer until the mid-June cutoff, then Fall.
+  expect_equal(get_default_reg_term(202610, TRUE, today = as.Date("2026-05-01")), 202660) # summer
+  expect_equal(get_default_reg_term(202610, TRUE, today = as.Date("2026-06-15")), 202660) # on cutoff -> still summer
+  expect_equal(get_default_reg_term(202610, TRUE, today = as.Date("2026-06-16")), 202680) # after cutoff -> fall
+
+  # Summer -> Fall and Fall -> next Spring are unambiguous (date irrelevant).
+  expect_equal(get_default_reg_term(202660, TRUE, today = as.Date("2026-07-01")), 202680)
+  expect_equal(get_default_reg_term(202680, TRUE, today = as.Date("2026-11-01")), 202710)
+})
+
+test_that("get_default_reg_term keys the summer cutoff off the term year, not the wall clock", {
+  # Current term is Spring 2025; a 2026 wall-clock date must not force the
+  # cutover — the 2025 summer window is what matters for a 2025 term.
+  expect_equal(get_default_reg_term(202510, TRUE, today = as.Date("2025-05-01")), 202560)
+  expect_equal(get_default_reg_term(202510, TRUE, today = as.Date("2025-08-01")), 202580)
+})
+
 test_that("term type helpers label fall/spring/summer", {
   df <- data.frame(term = c(202380, 202310, 202360))
   typed <- add_term_type_col(df, term)

--- a/ui.R
+++ b/ui.R
@@ -1289,7 +1289,7 @@ nav_panel(
   nav_panel(
     title = "Regstats",
     icon = icon("tachometer-alt"),
-    regstatsUI("regstats", cedar_sections, cedar_regstats_thresholds, .dept_choices, cedar_current_term)
+    regstatsUI("regstats", cedar_sections, cedar_regstats_thresholds, .dept_choices, cedar_default_reg_term)
   ), # end regstats nav_panel
 
 
@@ -1317,19 +1317,19 @@ nav_panel(
     nav_panel(
       title = "Open Seats",
       icon = icon("door-open"),
-      seatfinderUI("seatfinder", cedar_sections, cedar_next_term, .dept_choices)
+      seatfinderUI("seatfinder", cedar_sections, cedar_default_reg_term, .dept_choices)
     ), # end open seats nav_panel
 
     nav_panel(
       title = "Cancellations",
       icon = icon("ban"),
-      cancellationsUI("cancellations", cedar_sections, cedar_next_term, .dept_choices)
+      cancellationsUI("cancellations", cedar_sections, cedar_default_reg_term, .dept_choices)
     ), # end cancellations nav_panel
     
     nav_panel(
       title = "Waitlists",
       icon = icon("list-ol"),
-      waitlistUI("waitlist", cedar_sections, cedar_next_term, .dept_choices)
+      waitlistUI("waitlist", cedar_sections, cedar_default_reg_term, .dept_choices)
     ), # end waitlists nav_panel
 
     nav_panel(


### PR DESCRIPTION
## Problem

Open Seats, Waitlists, Cancellations, and Regstats each computed their own default term, and they didn't agree:

- **Open Seats / Waitlists / Cancellations** used `cedar_next_term` — the earliest term present in the sections data after the current term (data-driven, picks up summer, jumps ahead as soon as a schedule is loaded).
- **Regstats** used `add_term(cedar_current_term)` — pure arithmetic next *main* term (skips summer, ignores whether any data exists for it).

So the tabs could open on different terms (summer vs fall), and some jumped to the next term before its registration data was real.

There was already a config flag built for exactly this decision — `cedar_registration_underway` — but it had **zero consumers** anywhere in the code.

## Fix

One source of truth: `cedar_default_reg_term`, computed once in `global.R` from a new `get_default_reg_term()` helper, passed to all four tabs. It honors the manual flag:

- `cedar_registration_underway = FALSE` → default to the **current term**, so preliminary schedule builds don't present half-built next-term data as if it were real.
- `TRUE` → default to the **next term** students are registering for.

The only ambiguous step, Spring → (Summer vs Fall), is resolved by date: **Summer until a mid-June cutoff, then Fall**. Every other step (Summer→Fall, Fall→next Spring) is unambiguous. The cutoff's year is taken from the term being registered for, not the wall clock, so stale config degrades sanely.

### Changes
- New `get_default_reg_term(current_term, registration_underway, today, summer_cutoff)` in `R/trunk/utils.R`, with unit tests.
- `global.R` computes `cedar_default_reg_term` and drops the now-unused scalar `cedar_next_term`. (The unrelated `cedar_next_term` **data table** — the next-term return lookup used by Roadblocks/stopout — is untouched.)
- All four module UIs (`seatfinder`, `waitlist`, `cancellations`, `regstats`) take a `default_term` arg and use it directly; Regstats no longer computes its own `add_term()`.
- Both config templates document what `cedar_registration_underway` now drives.

## Decisions baked in (easy to change)
- **Manual flag** gates current-vs-next, per the "don't suggest wrong data on preliminary builds" requirement — not data presence (a schedule loads months before registration opens).
- **Mid-June cutoff = June 15** (`summer_cutoff = "06-15"` default in the helper). Adjustable in one place if that's off.
- **All four tabs unified**, including Cancellations (it shared the old `cedar_next_term` default, so leaving it out would just recreate the split).

## Verification
- Unit tests green: `get_default_reg_term` across flag-off, spring before/on/after cutoff, summer, fall, and the term-year cutoff case. Full suite `FAIL 0 | SKIP 38 | PASS 1729`.
- Built the image, ran it with data mounted, and read the rendered term selectors: all four tabs report `202610` (current term — flag is currently `FALSE`), confirming they're unified and driven by the shared value.

## Note for deploy
`cedar_registration_underway` is currently `FALSE` in the live config, so after this deploys all four tabs default to the **current** term. Flip it to `TRUE` once next-term registration is actually open to have them default to the next term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
