### PR TITLE
Fix Regstats Part-of-Term filter (add pt to the cache key)

### DIFF
--- a/R/reports/regstats.R
+++ b/R/reports/regstats.R
@@ -179,7 +179,18 @@ create_regstats_cache_filename <- function(opt) {
     campus_part <- gsub("[^A-Za-z0-9-]", "", campus_part)
     filename_parts <- c(filename_parts, campus_part)
   }
-  
+
+  # Add part-of-term filter. This MUST be in the key: pt changes the computed
+  # result (it filters which enrollments count), so two requests that differ
+  # only by PoT would otherwise collide on one cache file and the second would
+  # silently receive the first's result — making the PoT filter appear dead.
+  # Prefixed so the value ("1H") is unambiguous next to campus/level parts.
+  if (!is.null(opt[["pt"]]) && length(opt[["pt"]]) > 0) {
+    pt_part <- paste(sort(opt[["pt"]]), collapse = "-")
+    pt_part <- gsub("[^A-Za-z0-9-]", "", pt_part)
+    filename_parts <- c(filename_parts, paste0("pt", pt_part))
+  }
+
   # Join with underscores and add extension
   cache_filename <- paste(filename_parts, collapse = "_") 
   cache_filename <- paste0(cache_filename, ".Rds")

--- a/tests/testthat/test-regstats.R
+++ b/tests/testthat/test-regstats.R
@@ -418,6 +418,19 @@ test_that("create_regstats_cache_filename uses 'all-terms' when no term specifie
   expect_true(grepl("all-terms", result))
 })
 
+test_that("create_regstats_cache_filename encodes part-of-term so PoT requests don't collide", {
+  base_opt <- list(term = 202510, course_campus = "Main", dept = "MATH")
+  base     <- create_regstats_cache_filename(base_opt)
+  with_pt  <- create_regstats_cache_filename(c(base_opt, list(pt = "1H")))
+  other_pt <- create_regstats_cache_filename(c(base_opt, list(pt = "2H")))
+
+  # A PoT selection must change the cache key, and different PoTs must differ,
+  # otherwise get_reg_stats() serves a stale cached result for the new PoT.
+  expect_false(identical(base, with_pt))
+  expect_false(identical(with_pt, other_pt))
+  expect_true(grepl("pt1H", with_pt))
+})
+
 
 # =============================================================================
 # get_reg_stats() structure tests


### PR DESCRIPTION
## Problem

Selecting a **Part of Term** in the Regstats tab did nothing — the flagged courses and numbers were identical regardless of the PoT choice.

## Root cause

It's a **cache-key bug**, not a filtering bug. `get_reg_stats()` short-circuits to a cached result keyed on `create_regstats_cache_filename(opt)`, and that filename was assembled from only `course_college`, `dept`, `term`, `level`, and `course_campus`. It **omitted `pt`**.

So two requests differing only by Part of Term produced the *same* cache filename. The first run computed and cached; the second (different PoT) recomputed the same filename, found the cache, and returned the first run's result — so the PoT filter silently did nothing.

The compute path itself is correct: `filter_class_list` (student rows) and `get_enrl` → `filter_DESRs` (section rows) both apply `pt` properly. `pt` is the only result-affecting filter the Regstats UI/URL exposes that was missing from the key (custom thresholds already bypass the cache entirely).

## Fix

Add `pt` to the cache filename, prefixed so the value is unambiguous next to campus/level parts (e.g. `regstats_all-colleges_MATH_202580_ABQ_pt1H.Rds`).

## Verification (against production data)

- With `bypass_cache = TRUE`, outputs already differed by PoT (dips 8→1, bumps 8→∅, early_drops 4→1, sat 12→∅) — confirming the compute path was never the problem.
- Through the **normal cache path**: before the fix, no-PoT and `pt=1H` collided on one cache file (`..._ABQ.Rds`); after the fix they write and read separate files (`..._ABQ.Rds` and `..._ABQ_pt1H.Rds`) with correctly different results.
- Added a regression test asserting a PoT selection changes the cache key and different PoTs differ. Full suite: `FAIL 0 | SKIP 38 | PASS 1723`.

## Note
Existing cached `regstats_*.Rds` files without a `pt` segment are simply orphaned and regenerate on next use — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
