### PR TITLE
Treat part of term as a first-class dimension in Regstats

### DIFF
--- a/R/branches/enrl.R
+++ b/R/branches/enrl.R
@@ -36,7 +36,7 @@
 #' # Summarize only registered and dropped students:
 #' calc_cl_enrls(students_df, reg_status = c("RE", "DR"))
 
-calc_cl_enrls <- function(filtered_students, reg_status = NULL) {
+calc_cl_enrls <- function(filtered_students, reg_status = NULL, by_part_term = FALSE) {
 
   # filtered_students <- load_students()
   #opt <- list()
@@ -45,23 +45,35 @@ calc_cl_enrls <- function(filtered_students, reg_status = NULL) {
   # reg_status <- c("DR")
   # reg_status <- NULL
 
+  # Optional part-of-term dimension. Off by default so existing callers (course
+  # report, dept dashboard, forecasts, demographics) keep one row per course.
+  # Regstats turns it on so a full-term section and its 8-week half-term
+  # siblings are counted — and anomaly-compared — as the distinct entities they
+  # are, rather than lumped into one course total. Requires part_term on the
+  # input (present in cedar_students).
+  if (isTRUE(by_part_term) && !"part_term" %in% names(filtered_students)) {
+    stop("[enrl.R] calc_cl_enrls(by_part_term = TRUE) requires a part_term column in filtered_students")
+  }
+  pt_grp <- if (isTRUE(by_part_term)) "part_term" else character(0)
 
   reg_stats_summary <- tibble()
 
   # get distinct rows within courses; use subject_course to lump all sections topics courses together
   cedar_debug("[enrl.R] Getting distinct student within courses...")
   cl_enrls <- filtered_students %>%
-    group_by(campus, college, term, subject_course) %>%
+    group_by(across(all_of(c("campus", "college", "term", "subject_course", pt_grp)))) %>%
     distinct(student_id, .keep_all = TRUE)
 
   # count students in each term by reg status code
   cedar_debug("[enrl.R] Counting students in each campus/college/course/term by reg status code...")
-  cl_enrls <- cl_enrls %>% group_by(campus, college, subject_course, registration_status_code, term, term_type) %>%
+  cl_enrls <- cl_enrls %>%
+    group_by(across(all_of(c("campus", "college", "subject_course", "registration_status_code", "term", "term_type", pt_grp)))) %>%
     summarize(count = n(), .groups="keep")
 
   # calc mean reg codes per course and term type
   cedar_debug("[enrl.R] Calculating mean counts across terms...")
-  cl_enrls <- cl_enrls %>% group_by(campus, college, subject_course, term_type, registration_status_code) %>%
+  cl_enrls <- cl_enrls %>%
+    group_by(across(all_of(c("campus", "college", "subject_course", "term_type", "registration_status_code", pt_grp)))) %>%
     mutate(mean = round(mean(count),digits=1))
 
 
@@ -72,7 +84,7 @@ calc_cl_enrls <- function(filtered_students, reg_status = NULL) {
     # Uses conditional sum() instead of 6 separate filter+merge passes.
     # Zero-count buckets return 0 (not NA) because sum(integer(0)) == 0L.
     reg_stats_summary <- cl_enrls %>%
-      group_by(campus, college, subject_course, term, term_type) %>%
+      group_by(across(all_of(c("campus", "college", "subject_course", "term", "term_type", pt_grp)))) %>%
       summarize(
         registered = sum(count[registration_status_code %in% STATUS_REGISTERED]),
         dr_early   = sum(count[registration_status_code %in% STATUS_DROP_EARLY]),
@@ -86,7 +98,7 @@ calc_cl_enrls <- function(filtered_students, reg_status = NULL) {
     # Compute cross-term means grouped by term_type (drop term from grouping)
     cedar_debug("[enrl.R] calculating means across term types...")
     reg_stats_summary <- reg_stats_summary %>%
-      group_by(campus, college, subject_course, term_type) %>%
+      group_by(across(all_of(c("campus", "college", "subject_course", "term_type", pt_grp)))) %>%
       mutate(across(
         c(registered, dr_early, dr_late, dr_all, cl_total),
         ~ round(mean(.), digits = 2),

--- a/R/modules/regstats.R
+++ b/R/modules/regstats.R
@@ -223,6 +223,15 @@ regstatsServer <- function(id, students, sections, course_flows, data_summary, t
           cell = function(v) htmltools::span(class = "fw-semibold", v)),
         course_title   = reactable::colDef(name = "Title",      minWidth = 130,
           cell = function(v) if (!is.na(v)) htmltools::span(class = "text-sub", v) else ""),
+        # Part of term. Full-term ("1") is the common case and dimmed; the
+        # half-term / nonstandard variants (1H, 2H, INT, ...) stand out because
+        # they are analyzed as distinct offerings, not folded into the course.
+        part_term      = reactable::colDef(name = "PoT", maxWidth = 60, align = "center",
+          cell = function(v) {
+            if (is.na(v) || v == "" || v == "1")
+              htmltools::span(class = "text-sub", if (is.na(v) || v == "") "—" else "Full")
+            else htmltools::span(class = "fw-semibold", v)
+          }),
         college        = reactable::colDef(name = "College",    maxWidth = 80),
         term           = reactable::colDef(name = "Term",       maxWidth = 75),
         term_type      = reactable::colDef(show = FALSE),

--- a/R/reports/regstats.R
+++ b/R/reports/regstats.R
@@ -632,7 +632,7 @@ get_reg_stats <- function(students, courses, opt) {
   } else {
     cedar_debug("[regstats.R] Falling back to filter_class_list + calc_cl_enrls (student-level filters active)...")
     filtered_students <- filter_class_list(students, myopt)
-    regstats <- calc_cl_enrls(filtered_students)
+    regstats <- calc_cl_enrls(filtered_students, by_part_term = TRUE)
   }
 
   # Replace biased _mean columns (which include the target term) with historical-only means.
@@ -643,8 +643,11 @@ get_reg_stats <- function(students, courses, opt) {
 
     if (nrow(hist_rows) > 0) {
       cedar_debug("[regstats.R] Replacing means with historical-only values (excluding ", paste(target_terms, collapse = ", "), ")...")
+      # Baselines are matched on part_term as well as term_type, so a 2H section's
+      # enrollment is compared against the history of 2H offerings of that course,
+      # not diluted by the full-term sections.
       hist_means <- hist_rows %>%
-        group_by(campus, college, subject_course, term_type) %>%
+        group_by(campus, college, subject_course, term_type, part_term) %>%
         summarize(
           registered_mean = round(mean(registered), digits = 2),
           dr_early_mean   = round(mean(dr_early),   digits = 2),
@@ -658,7 +661,7 @@ get_reg_stats <- function(students, courses, opt) {
       regstats <- regstats %>%
         select(-registered_mean, -dr_early_mean, -dr_late_mean, -dr_all_mean, -cl_total_mean,
                -any_of("n_hist_terms")) %>%
-        left_join(hist_means, by = c("campus", "college", "subject_course", "term_type"))
+        left_join(hist_means, by = c("campus", "college", "subject_course", "term_type", "part_term"))
 
       cedar_debug("[regstats.R] Mean columns replaced with historical-only values.")
     } else {
@@ -670,8 +673,8 @@ get_reg_stats <- function(students, courses, opt) {
   # use biased SD calc, since we're not really sampling from a population
   cedar_debug("[regstats.R] Finding courses of interest...")
   flagged <- list()
-  std_fields <- c("campus", "college","subject_course","term","term_type","registered")
-  std_group_cols <- c("campus", "college","subject_course","term_type")
+  std_fields <- c("campus", "college","subject_course","part_term","term","term_type","registered")
+  std_group_cols <- c("campus", "college","subject_course","term_type","part_term")
   #std_arrange_cols <- c("campus","term","impacted")
   std_arrange_cols <- c("campus", "college")
   
@@ -791,7 +794,7 @@ flagged[["bumps"]] <- bumps %>% arrange(across(all_of(std_arrange_cols)))
   cedar_debug("[regstats.R] Finding waits...")
   myopt <- opt
   myopt[["uel"]] <- TRUE
-  myopt[["group_cols"]] <- c("campus","college","term", "subject_course", "gen_ed_area")
+  myopt[["group_cols"]] <- c("campus","college","term", "subject_course", "part_term", "gen_ed_area")
   enrls <- get_enrl(courses, myopt)
   waits <-  enrls %>% filter (waiting > thresholds[["min_wait"]]) %>% arrange (desc(waiting))
   # No rename needed - already using CEDAR column name 'term'
@@ -813,7 +816,7 @@ flagged[["bumps"]] <- bumps %>% arrange(across(all_of(std_arrange_cols)))
   sat_opt <- opt
   sat_opt[["term"]] <- NULL
   sat_opt[["uel"]] <- TRUE
-  sat_opt[["group_cols"]] <- c("campus", "college", "term", "subject_course")
+  sat_opt[["group_cols"]] <- c("campus", "college", "term", "subject_course", "part_term")
   sat_enrls <- get_enrl(courses, sat_opt)
   message("[regstats.R] sat_enrls: ", nrow(sat_enrls), " rows, terms: ",
           paste(sort(unique(sat_enrls$term)), collapse = ", "))
@@ -840,7 +843,7 @@ flagged[["bumps"]] <- bumps %>% arrange(across(all_of(std_arrange_cols)))
           paste(sort(unique(hist_sat$term)), collapse = ", "))
 
   fill_baselines <- hist_sat %>%
-    group_by(campus, college, subject_course, term_type) %>%
+    group_by(campus, college, subject_course, term_type, part_term) %>%
     summarize(
       fill_rate_mean  = round(mean(fill_rate, na.rm = TRUE), 3),
       fill_rate_sd    = round(sd(fill_rate,   na.rm = TRUE), 3),
@@ -854,7 +857,7 @@ flagged[["bumps"]] <- bumps %>% arrange(across(all_of(std_arrange_cols)))
                 table(fill_baselines$n_hist_terms), sep="=", collapse=", "))
 
   sat <- sat_all %>%
-    left_join(fill_baselines, by = c("campus", "college", "subject_course", "term_type")) %>%
+    left_join(fill_baselines, by = c("campus", "college", "subject_course", "term_type", "part_term")) %>%
     mutate(
       fill_rate_delta = round(fill_rate - fill_rate_mean, 3),
       sd_above_mean   = if_else(

--- a/global.R
+++ b/global.R
@@ -312,6 +312,17 @@ if (!is.null(data_objects[["cedar_students"]]) && nrow(data_objects[["cedar_stud
                  file.exists(students_qs_path) &&
                  file.info(base_cache_path)$mtime > file.info(students_qs_path)$mtime
 
+  # Shape guard: a base cached before the part_term dimension was added is
+  # mtime-valid but missing the column, which would break the part-aware
+  # regstats groupings. Treat a base without part_term as stale so it recomputes.
+  if (cache_valid) {
+    cached_cols <- tryCatch(names(qs2::qs_read(base_cache_path)), error = function(e) character(0))
+    if (!"part_term" %in% cached_cols) {
+      message("[global.R] Cached enrollment base predates part_term; recomputing.")
+      cache_valid <- FALSE
+    }
+  }
+
   if (cache_valid) {
     message("[global.R] Loading cached enrollment base table...")
     t_base <- system.time({ cedar_cl_enrls_base <- qs2::qs_read(base_cache_path) })
@@ -320,7 +331,7 @@ if (!is.null(data_objects[["cedar_students"]]) && nrow(data_objects[["cedar_stud
   } else {
     message("[global.R] Pre-computing enrollment stats base table for regstats...")
     t_base <- system.time({
-      cedar_cl_enrls_base <- calc_cl_enrls(data_objects[["cedar_students"]])
+      cedar_cl_enrls_base <- calc_cl_enrls(data_objects[["cedar_students"]], by_part_term = TRUE)
 
       # One row per subject_course for level/department lookup; slice(1) handles
       # rare crosslist cases where the same course appears under multiple departments.

--- a/tests/testthat/test-enrollment.R
+++ b/tests/testthat/test-enrollment.R
@@ -293,6 +293,38 @@ test_that("calc_cl_enrls zero-count status columns are 0, not NA", {
               info = "wl_all must be 0 not NA when no waitlisted students exist")
 })
 
+test_that("calc_cl_enrls by_part_term adds the part_term dimension only when requested", {
+  hist <- test_students %>% filter(department == "HIST")
+
+  default_out <- calc_cl_enrls(hist)
+  part_out    <- calc_cl_enrls(hist, by_part_term = TRUE)
+
+  # Off by default so existing callers keep one row per course/term.
+  expect_false("part_term" %in% names(default_out))
+  # On request, part_term becomes a grouping column carried into the output.
+  expect_true("part_term" %in% names(part_out))
+})
+
+test_that("calc_cl_enrls by_part_term preserves single-part counts", {
+  # The fixtures have no part-of-term variation, so turning the dimension on
+  # must not change the enrollment counts — it only adds the column.
+  hist <- test_students %>% filter(department == "HIST")
+
+  default_row <- calc_cl_enrls(hist) %>%
+    filter(subject_course == "HIST 1110", term == 202010L, campus == "ABQ")
+  part_row <- calc_cl_enrls(hist, by_part_term = TRUE) %>%
+    filter(subject_course == "HIST 1110", term == 202010L, campus == "ABQ")
+
+  expect_equal(nrow(part_row), 1)
+  expect_equal(part_row$registered, default_row$registered)
+  expect_equal(part_row$dr_all,     default_row$dr_all)
+})
+
+test_that("calc_cl_enrls by_part_term stops loudly when part_term is absent", {
+  no_pt <- test_students %>% filter(department == "HIST") %>% select(-part_term)
+  expect_error(calc_cl_enrls(no_pt, by_part_term = TRUE), "part_term")
+})
+
 test_that("calc_cl_enrls registered_mean is mean across term_type not raw sum", {
   # HIST 1110 appears in SP (202010, 202110) and FA (202080) terms.
   # registered_mean for SP rows = mean of the two spring registered counts.


### PR DESCRIPTION
## What & why

Regstats lumped all parts of term of a course into one number. That's what made ENGL 2210 read **219** in Regstats while Open Seats (which splits by part of term) showed **174** for the full-term sections alone — same data, different granularity. Lumping also masked part-specific anomalies: an 8-week section filling abnormally fast was diluted by the full-term average.

This makes **part of term a first-class dimension** of the enrollment analysis, exactly parallel to how `term_type` is already handled — split the rows *and* match baselines by part.

## Changes

- **`calc_cl_enrls()`** gains an opt-in `by_part_term` flag (default `FALSE`). Off by default so the other callers — course report, dept dashboard, forecast, demographics — keep one row per course and are unchanged. On, it carries `part_term` through every grouping and fails loudly if the column is missing.
- **Precomputed base (`global.R`)** is built with `by_part_term = TRUE`. A base cached before this change lacks `part_term`; it's now detected by a column check and recomputed instead of loaded stale (the mtime check alone wouldn't catch a shape change).
- **`get_reg_stats()`** flows `part_term` through the fallback recompute, the historical-mean baselines (`hist_means` + join), the anomaly groupings (`std_fields` / `std_group_cols` → dips/bumps/early+late drops), and the waits + saturation baselines. **Baselines are part-matched** — a 2H section is compared against 2H history, not the full-term average.
- **Module table** gains a `PoT` column. Full term shows dimmed as "Full"; the `1H` / `2H` / `INT` variants are bolded so multi-part courses are obvious.

## Result

ENGL 2210 / EA / Fall 2026 now appears as three separate, separately-analyzed rows:

| PoT | Enrolled |
|-----|----------|
| Full (`1`) | 174 ← now matches Open Seats |
| `1H` | 20 |
| `2H` | 25 |

## Verification

- Full suite green (`FAIL 0 | SKIP 38 | PASS 1738`).
- New unit tests: the `by_part_term` column contract (adds `part_term` only when requested), single-part invariance (fixtures have no part variation, so counts are unchanged), and the missing-column guard.
- End-to-end against production data: `calc_cl_enrls` returns 174 / 20 / 25 (summing to 219) for ENGL 2210 / EA / Fall 2026, and every `get_reg_stats` anomaly table (`dips`, `bumps`, `early_drops`, `late_drops`, `sat`) carries `part_term`.

## Notes
- The PoT **filter** already scopes table + stats correctly (fixed earlier in #46); this change is about the **default** (no-filter) view splitting rather than lumping.
- Overview cards (`n_waitlisted`, trend avg size) now count part-offerings rather than whole courses — directionally consistent with "parts are distinct entities," and not part of the anomaly flagging.
- Test fixtures have no part-of-term variation (all `part_term` NA), so the actual split is verified against production data rather than fixtures; adding a PoT edge case to the fixtures is a reasonable follow-up if we want it covered in-suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
