### PR TITLE
Count each crosslist group once in aggregated total_enrl

### DIFF
--- a/R/branches/enrl.R
+++ b/R/branches/enrl.R
@@ -219,7 +219,11 @@ compress_aop_pairs <- function(courses, opt) {
 #'     \item{xl_sections}{Number of crosslisted sections (crosslist_code != "0")}
 #'     \item{reg_sections}{Number of regular (non-crosslisted) sections}
 #'     \item{avg_size}{Average enrollment per section (rounded to 1 decimal)}
-#'     \item{enrolled}{Total enrollment across all sections}
+#'     \item{total_enrl}{Crosslist-aware total: each crosslist group's combined
+#'       enrollment counted once, plus own enrollment of non-crosslisted
+#'       sections. For a cross-course crosslist this includes partner-course
+#'       students, so it can exceed \code{enrolled}.}
+#'     \item{enrolled}{Total enrollment across all sections (own students only)}
 #'     \item{avail}{Total available seats across all sections}
 #'     \item{waiting}{Total waitlist count across all sections}
 #'   }
@@ -245,18 +249,62 @@ compress_aop_pairs <- function(courses, opt) {
 #' summary <- summarize_courses(cedar_sections, opt)
 #' }
 #'
+#' Course-level total enrollment with each crosslist group counted once
+#'
+#' Every section row in a crosslist group carries the group's combined
+#' enrollment in total_enrl (transform-to-cedar.R sets it to
+#' pmax(ENROLLED, XL_TOTAL_ENROLLMENT)). Summing total_enrl over the rows of a
+#' group therefore multiply-counts it — once per section. A same-course
+#' internal group of 4 sections sharing a combined total of 96 sums to 384
+#' (this is what made BIOL 2305 report ~4x its real enrollment).
+#'
+#' Within one aggregation cell, count each crosslist group's combined total
+#' once (max over the group's identical values) and use each non-crosslisted
+#' row's own enrollment. Cross-course groups keep their intended semantics:
+#' each course's cell contains its own rows of the group, so each course sees
+#' the combined total once.
+#'
+#' @param own Per-row own enrollment, used for rows with no crosslist group.
+#' @param group_total Per-row crosslist-combined enrollment (total_enrl).
+#' @param xl_key Crosslist group key (e.g. "term|campus|code"); NA for
+#'   non-crosslisted rows.
+sum_xl_dedup_total <- function(own, group_total, xl_key) {
+  is_xl <- !is.na(xl_key)
+  total <- sum(own[!is_xl], na.rm = TRUE)
+  if (any(is_xl)) {
+    group_totals <- tapply(group_total[is_xl], xl_key[is_xl], max, na.rm = TRUE)
+    total <- total + sum(group_totals)
+  }
+  total
+}
+
 #' @seealso \code{\link{get_enrl}}, \code{\link{aggregate_courses}}
 summarize_courses <- function(courses, opt) {
 
-  # total_enrl must be present — it is set by transform-to-cedar.R (pmax(ENROLLED, XL_ENRL))
-  # and preserved through get_enrl()'s select step. If it is missing here, the data was
-  # not sourced from cedar_sections or was transformed in a way that dropped the column.
-  # Silently substituting enrolled would produce wrong numbers for XL courses with no trace.
-  if (!"total_enrl" %in% names(courses)) {
-    stop("[enrl.R] summarize_courses: 'total_enrl' column missing. ",
-         "Data must come from cedar_sections (via get_enrl). ",
+  # These columns are set by transform-to-cedar.R and preserved through
+  # get_enrl()'s select step (crosslist_code gets a "0" placeholder there when
+  # absent). If any is missing, the data was not sourced from cedar_sections.
+  # Silently substituting (e.g. enrolled for total_enrl) would produce wrong
+  # numbers for crosslisted courses with no trace.
+  required_cols <- c("total_enrl", "enrolled", "term", "campus", "crosslist_code")
+  missing_required <- setdiff(required_cols, names(courses))
+  if (length(missing_required) > 0) {
+    stop("[enrl.R] summarize_courses: missing required column(s): ",
+         paste(missing_required, collapse = ", "),
+         ". Data must come from cedar_sections (via get_enrl). ",
          "Columns present: ", paste(sort(names(courses)), collapse = ", "))
   }
+
+  # Crosslist group key for total_enrl dedup: codes are unique within a term,
+  # so scope the key by term (and campus for safety). NA marks non-crosslisted
+  # rows, which contribute their own enrolled count instead.
+  courses <- courses %>%
+    ungroup() %>%
+    mutate(.xl_key = dplyr::if_else(
+      !is.na(crosslist_code) & crosslist_code != "0" & crosslist_code != "",
+      paste(term, campus, crosslist_code, sep = "|"),
+      NA_character_
+    ))
 
   # set default group_cols
   # group by course_title to differentiate topics courses that use same subject_course
@@ -292,8 +340,11 @@ summarize_courses <- function(courses, opt) {
       xl_sections=sum(crosslist_code != "0" & crosslist_code != "", na.rm=TRUE),
       reg_sections=sum(crosslist_code == "0" | crosslist_code == "" | is.na(crosslist_code)),
       avg_size=round(mean(enrolled, na.rm=TRUE),digits=1),
+      # Each crosslist group's combined total counted once — see sum_xl_dedup_total().
+      # Computed BEFORE enrolled is reassigned below: summarize() evaluates
+      # sequentially, so after `enrolled=sum(...)` the name refers to the scalar.
+      total_enrl=sum_xl_dedup_total(enrolled, total_enrl, .xl_key),
       enrolled=sum(enrolled, na.rm=TRUE),
-      total_enrl=sum(total_enrl, na.rm=TRUE),
       avail=sum(available, na.rm=TRUE),
       waiting=sum(waitlist_count, na.rm=TRUE),
       .groups="keep")
@@ -789,16 +840,16 @@ get_enrl <- function(courses, opt) {
   #   Fix: do NOT dedup these courses.
   #
   # Pattern C — internal crosslist (crosslist_role == "internal"):
-  #   Multiple internal crosslist groups (e.g., BIOL 300C groups "5Z" and "H").
+  #   Multiple internal crosslist groups (e.g., BIOL 300C groups "5Z" and "H";
+  #   also non-combined courses like BIOL 2305 with several multi-CRN groups).
   #   The home filter keeps ALL internal rows, and sum(enrolled) within each group
-  #   equals total_enrl for that group. The natural sum across all groups is correct.
+  #   equals total_enrl for that group. The natural sum of enrolled is correct.
   #   Individual rows have total_enrl > enrolled (total_enrl is the group total, not
   #   the row's per-section count), which would falsely trigger the Pattern A tag.
   #   Fix (section level): exclude internal-crosslist rows from Pattern A detection.
-  #   Fix (aggregation): normalize total_enrl = enrolled before summarize_courses so
-  #   sum(total_enrl) = sum(enrolled) = correct course total. Without this, the naive
-  #   sum overcounts: 4 rows × group_total (e.g. 4 × 89 = 356 instead of 89).
-  #   See the "Pattern C normalization" block below, applied just before aggregation.
+  #   Fix (aggregation): summarize_courses() counts each crosslist group's
+  #   total_enrl once per cell (sum_xl_dedup_total), so no normalization is
+  #   needed here. A naive sum would overcount: 4 rows × group_total.
   #
   # Distinguishing A from B: among non-internal rows, check whether total_enrl > enrolled
   # on any row in the course group (before correction).
@@ -933,35 +984,12 @@ get_enrl <- function(courses, opt) {
       arrange(across(all_of(c(group_arrange_cols, detail_arrange_cols))))
   }
 
-  # Pattern C normalization — aggregation path only.
-  # Internal crosslist combined rows carry total_enrl = the group total (not the
-  # row's own per-section enrollment). When summarize_courses sums these, it gets
-  # n_rows × group_total instead of the correct course sum (e.g. 4 × 89 = 356).
-  # Fix: set total_enrl = enrolled for each internal row so sum(total_enrl) =
-  # sum(enrolled) = correct course total after aggregation.
-  # This is ONLY applied on the aggregation path. Section-level callers like
-  # get_low_enrollment_courses depend on total_enrl reflecting the group total
-  # for threshold comparison, so those must NOT be normalized.
-  if ((!is.null(opt$aggregate) || !is.null(opt$group_cols)) &&
-      "crosslist_role" %in% colnames(courses) &&
-      "is_combined"   %in% colnames(courses)) {
-    n_internal <- sum(
-      courses$is_combined & !is.na(courses$crosslist_role) & courses$crosslist_role == "internal",
-      na.rm = TRUE
-    )
-    if (n_internal > 0) {
-      message("[enrl.R] Normalizing total_enrl = enrolled for ", n_internal,
-              " Pattern C internal-crosslist combined rows (aggregation path)")
-      courses <- courses %>%
-        dplyr::mutate(
-          total_enrl = dplyr::if_else(
-            is_combined & !is.na(crosslist_role) & crosslist_role == "internal",
-            enrolled,
-            total_enrl
-          )
-        )
-    }
-  }
+  # NOTE on aggregated total_enrl: section rows in a crosslist group each carry
+  # the group's combined total, so summing them would multiply-count the group.
+  # summarize_courses() handles this by counting each crosslist group's total
+  # once per aggregation cell (sum_xl_dedup_total) — no per-row normalization is
+  # needed here, and section-level callers (e.g. get_low_enrollment_courses)
+  # still see the raw per-row group totals they depend on.
 
   # check if aggregating
   if(!is.null(opt$aggregate) || !is.null(opt$group_cols)) {
@@ -1025,10 +1053,19 @@ get_course_section_counts <- function(sections) {
   sections %>%
     filter(status == "A") %>%
     filter(is.na(crosslist_group) | crosslist_role %in% c("home", "internal")) %>%
+    # Rows in a crosslist group each carry the group's combined total_enrl, so
+    # count each group once (multi-CRN internal groups like BIOL 2305 would
+    # otherwise be multiply-counted). Non-crosslisted rows: total_enrl equals
+    # the row's own enrollment.
+    mutate(.xl_key = dplyr::if_else(
+      !is.na(crosslist_group) & crosslist_group != "" & crosslist_group != "0",
+      paste(term, campus, crosslist_group, sep = "|"),
+      NA_character_
+    )) %>%
     group_by(term, subject_course, course_title, campus) %>%
     summarize(
       n_sections  = n(),
-      course_enrl = sum(total_enrl, na.rm = TRUE),
+      course_enrl = sum_xl_dedup_total(total_enrl, total_enrl, .xl_key),
       .groups = "drop"
     )
 }

--- a/tests/testthat/fixtures/designed_test_data.R
+++ b/tests/testthat/fixtures/designed_test_data.R
@@ -58,8 +58,10 @@
 #   EC-04 — Pattern A non-crosslisted C: BIOL 2110C (4 CRNs, enrolled=22/22/23/22, total_enrl=89)
 #   EC-05 — Pattern B non-crosslisted C: BIOL 304C  (4 CRNs, enrolled=25/22/22/20, total_enrl=same)
 #   EC-06 — Pattern C internal crosslist C: BIOL 300C (2 groups × 3 CRNs; group 6G sum=92, group 62 sum=138)
+#   EC-07 — internal crosslist, NOT combined: BIOL 2305 (1 group × 3 CRNs; enrolled=24/24/23,
+#           total_enrl=71 on every row — correct course total counts the group once, not 3×71)
 # XL crosslist_primary=TRUE: 6  |  is_split=TRUE: 7  |  crosslist_external=TRUE: 6
-# is_combined=TRUE: 17 (XL06=3, EC-04=4, EC-05=4, EC-06=6)
+# is_combined=TRUE: 17 (XL06=3, EC-04=4, EC-05=4, EC-06=6); internal non-combined: EC-07=3
 # Tests filter with filter(!is.na(crosslist_group)) to get this subset.
 #
 # === CEDAR_STUDENTS ===
@@ -1148,7 +1150,51 @@ cedar_sections_xl <- tribble(
   4.0,4.0, as.Date("2020-08-17"),as.Date("2020-12-12"),
   "62","62","internal",
   FALSE,NA_character_,NA_character_,
-  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17")
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17"),
+
+  # --- EC-07: BIOL 2305 — internal crosslist, NOT combined (no C suffix) ---
+  # Mimics the real BIOL 2305 pattern: one internal group of 3 CRNs where every
+  # row carries the group's combined total (71) in total_enrl while enrolled is
+  # the per-section count (24/24/23, sum = 71). is_combined = FALSE, so this
+  # slips past any is_combined-gated handling. A naive sum(total_enrl) over the
+  # group multiply-counts it (3 × 71 = 213); the correct course-level
+  # total_enrl counts the group once (71). This is the case that made the real
+  # BIOL 2305 report ~4x its actual enrollment.
+  "EC-202080-N01", 202080L, "ECN01", "BIOL","2305","BIOL 2305","001",
+  "Human Anatomy and Physiology I",  "1","ABQ","AS","BIOL",
+  "INS007","Anatomy, Instructor",
+  24L,71L,25L,1L,
+  "A","ENH","lower","FA",
+  0L,0L,
+  TRUE, FALSE,
+  4.0,4.0, as.Date("2020-08-17"),as.Date("2020-12-12"),
+  "E7","E7","internal",
+  FALSE,NA_character_,NA_character_,
+  FALSE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17"),
+
+  "EC-202080-N02", 202080L, "ECN02", "BIOL","2305","BIOL 2305","002",
+  "Human Anatomy and Physiology I",  "1","ABQ","AS","BIOL",
+  "INS007","Anatomy, Instructor",
+  24L,71L,25L,1L,
+  "A","ENH","lower","FA",
+  0L,0L,
+  FALSE, FALSE,
+  4.0,4.0, as.Date("2020-08-17"),as.Date("2020-12-12"),
+  "E7","E7","internal",
+  FALSE,NA_character_,NA_character_,
+  FALSE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17"),
+
+  "EC-202080-N03", 202080L, "ECN03", "BIOL","2305","BIOL 2305","003",
+  "Human Anatomy and Physiology I",  "1","ABQ","AS","BIOL",
+  "INS007","Anatomy, Instructor",
+  23L,71L,25L,2L,
+  "A","ENH","lower","FA",
+  0L,0L,
+  FALSE, FALSE,
+  4.0,4.0, as.Date("2020-08-17"),as.Date("2020-12-12"),
+  "E7","E7","internal",
+  FALSE,NA_character_,NA_character_,
+  FALSE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17")
 )
 
 # Merge XL sections into the main table. In production, crosslisted sections live

--- a/tests/testthat/test-crosslist-split.R
+++ b/tests/testthat/test-crosslist-split.R
@@ -37,9 +37,10 @@ test_that("crosslist_group is NA for non-crosslisted sections", {
 
 test_that("crosslist_group is set to the XL code for crosslisted sections", {
   expect_true(all(!is.na(xl_sections$crosslist_group)))
-  # XL01-XL06: external crosslists; 6G+62: internal crosslist groups from EC-06
+  # XL01-XL06: external crosslists; 6G+62: internal crosslist groups from EC-06;
+  # E7: internal non-combined group from EC-07 (BIOL 2305)
   expect_setequal(unique(xl_sections$crosslist_group),
-                  c("XL01", "XL02", "XL03", "XL04", "XL05", "XL06", "6G", "62"))
+                  c("XL01", "XL02", "XL03", "XL04", "XL05", "XL06", "6G", "62", "E7"))
 })
 
 test_that("crosslist_group matches crosslist_code for XL sections", {
@@ -159,10 +160,11 @@ test_that("total is_split sections = 7 (XL02:2 + XL03:2 + XL05:3)", {
   expect_equal(sum(xl_sections$is_split), 7)
 })
 
-test_that("total non-split XL sections = 13 (XL01:2 + XL04:2 + XL06:3 + EC-06:6)", {
+test_that("total non-split XL sections = 16 (XL01:2 + XL04:2 + XL06:3 + EC-06:6 + EC-07:3)", {
   non_split <- xl_sections %>% filter(!is_split)
   # 7 original (XL01, XL04, XL06) + 6 internal-crosslist C-suffix rows from EC-06
-  expect_equal(nrow(non_split), 13)
+  # + 3 internal non-combined rows from EC-07 (BIOL 2305)
+  expect_equal(nrow(non_split), 16)
   expect_true(all(non_split$level %in% c("upper", "lower")))
 })
 
@@ -195,9 +197,9 @@ test_that("crosslist home filter on XL subset keeps exactly one section per grou
   result <- filter_DESRs(xl_sections, opt)
 
   # External XL groups (XL01-XL06): 1 primary per group = 6 rows
-  # Internal XL groups (6G, 62 from EC-06): all rows kept = 6 rows
-  # Total: 12 rows
-  expect_equal(nrow(result), 12)
+  # Internal XL groups (6G, 62 from EC-06; E7 from EC-07): all rows kept = 9 rows
+  # Total: 15 rows
+  expect_equal(nrow(result), 15)
 
   # External groups: only the primary survives
   external <- result %>% filter(crosslist_role != "internal")

--- a/tests/testthat/test-enrollment.R
+++ b/tests/testthat/test-enrollment.R
@@ -49,10 +49,10 @@ test_that("summarize_courses enrolled totals match fixture per term", {
   opt    <- list(group_cols = c("term"))
   result <- summarize_courses(active, opt) %>% arrange(term)
 
-  # 202080 (Fall 2020): 18 base + 14 C-suffix sections (EC-04:4, EC-05:4, EC-06:6) = 32
-  # enrolled for 202080: 370 base + 89 (EC-04) + 89 (EC-05) + 230 (EC-06) = 778
-  expect_equal(result$sections, c(28, 12, 32, 17))
-  expect_equal(result$enrolled, c(462, 217, 778, 344))
+  # 202080 (Fall 2020): 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) + EC-07:3 = 35
+  # enrolled for 202080: 370 base + 89 (EC-04) + 89 (EC-05) + 230 (EC-06) + 71 (EC-07) = 849
+  expect_equal(result$sections, c(28, 12, 35, 17))
+  expect_equal(result$enrolled, c(462, 217, 849, 344))
 })
 
 test_that("summarize_courses xl_sections and reg_sections sum to sections", {
@@ -138,9 +138,10 @@ test_that("get_enrl aggregated by term returns 4 rows with correct totals", {
   result <- get_enrl(test_sections, opt) %>% arrange(term)
 
   expect_equal(nrow(result), 4)
-  # 202080: 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) = 32; enrolled=370+89+89+230=778
-  expect_equal(result$sections, c(28, 12, 32, 17))
-  expect_equal(result$enrolled, c(462, 217, 778, 344))
+  # 202080: 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) + EC-07:3 = 35
+  # enrolled: 370+89+89+230+71 (EC-07) = 849
+  expect_equal(result$sections, c(28, 12, 35, 17))
+  expect_equal(result$enrolled, c(462, 217, 849, 344))
 })
 
 test_that("get_enrl filters by department correctly", {
@@ -323,6 +324,57 @@ test_that("calc_cl_enrls by_part_term preserves single-part counts", {
 test_that("calc_cl_enrls by_part_term stops loudly when part_term is absent", {
   no_pt <- test_students %>% filter(department == "HIST") %>% select(-part_term)
   expect_error(calc_cl_enrls(no_pt, by_part_term = TRUE), "part_term")
+})
+
+
+# =============================================================================
+# Aggregated total_enrl — crosslist groups counted once (sum_xl_dedup_total)
+#
+# Every section row in a crosslist group carries the group's combined total in
+# total_enrl, so a naive sum(total_enrl) multiply-counts the group. This is the
+# bug that made the real BIOL 2305 report ~4x its actual enrollment.
+# =============================================================================
+
+test_that("aggregated total_enrl counts a non-combined internal group once (EC-07 / BIOL 2305)", {
+  # EC-07: 3 CRNs in internal group E7, enrolled 24/24/23, each row total_enrl=71.
+  # Naive sum = 3 x 71 = 213; correct course-level total_enrl = 71.
+  opt <- list(term = 202080, status = "A", uel = FALSE,
+              group_cols = c("campus", "term", "subject_course"))
+  result <- get_enrl(test_sections, opt) %>%
+    filter(subject_course == "BIOL 2305")
+
+  expect_equal(nrow(result), 1)
+  expect_equal(result$sections,   3L)
+  expect_equal(result$enrolled,   71L)
+  expect_equal(result$total_enrl, 71)
+})
+
+test_that("aggregated total_enrl counts each of multiple internal groups once (EC-06 / BIOL 300C)", {
+  # EC-06: 2 internal groups (6G total=92, 62 total=138), 3 CRNs each.
+  # Correct course-level total_enrl = 92 + 138 = 230 (not 3x92 + 3x138 = 690).
+  opt <- list(term = 202080, status = "A", uel = FALSE,
+              group_cols = c("campus", "term", "subject_course"))
+  result <- get_enrl(test_sections, opt) %>%
+    filter(subject_course == "BIOL 300C")
+
+  expect_equal(nrow(result), 1)
+  expect_equal(result$total_enrl, 230)
+})
+
+test_that("aggregated total_enrl keeps combined-with-partner semantics for cross-course groups", {
+  # XL02: HIST 484 (8 enrolled) + HIST 584 (3 enrolled) share group total 11.
+  # Each course's cell holds one row of the group, so each course reports the
+  # combined total (11) — larger than its own enrolled. The dedup must not
+  # change this: it only prevents counting a group twice WITHIN a cell.
+  opt <- list(term = 202010, status = "A", uel = FALSE,
+              group_cols = c("campus", "term", "subject_course"))
+  result <- get_enrl(test_sections, opt)
+
+  h484 <- result %>% filter(subject_course == "HIST 484")
+  h584 <- result %>% filter(subject_course == "HIST 584")
+  expect_equal(h484$total_enrl, 11)
+  expect_equal(h584$total_enrl, 11)
+  expect_equal(h484$enrolled,   8L)
 })
 
 test_that("calc_cl_enrls registered_mean is mean across term_type not raw sum", {

--- a/tests/testthat/test-filtering.R
+++ b/tests/testthat/test-filtering.R
@@ -93,8 +93,8 @@ test_that("filter_DESRs filters by term 202080 correctly", {
   opt <- make_opt(term = 202080)
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 18 base + 14 C-suffix rows (EC-04:4, EC-05:4, EC-06:6) = 32
-  expect_equal(nrow(filtered), 32)
+  # 18 base + 14 C-suffix rows (EC-04:4, EC-05:4, EC-06:6) + 3 EC-07 = 35
+  expect_equal(nrow(filtered), 35)
   expect_true(all(filtered$term == 202080))
 })
 
@@ -114,8 +114,8 @@ test_that("filter_DESRs filters by ABQ campus correctly", {
   opt <- make_opt(course_campus = "ABQ")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 67 base + 14 C-suffix rows (all ABQ campus) = 81
-  expect_equal(nrow(filtered), 81)
+  # 67 base + 14 C-suffix + 3 EC-07 rows (all ABQ campus) = 84
+  expect_equal(nrow(filtered), 84)
   expect_true(all(filtered$campus == "ABQ"))
 })
 
@@ -143,8 +143,8 @@ test_that("filter_DESRs filters by active status explicitly", {
   opt <- make_opt(status = "A")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 75 base + 14 C-suffix rows (all status="A") = 89
-  expect_equal(nrow(filtered), 89)
+  # 75 base + 14 C-suffix + 3 EC-07 rows (all status="A") = 92
+  expect_equal(nrow(filtered), 92)
   expect_true(all(filtered$status == "A"))
 })
 
@@ -172,8 +172,8 @@ test_that("filter_DESRs filters by ENH delivery correctly", {
   opt <- make_opt(im = "ENH")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 46 base + 14 C-suffix rows (all delivery="ENH") = 60
-  expect_equal(nrow(filtered), 60)
+  # 46 base + 14 C-suffix + 3 EC-07 rows (all delivery="ENH") = 63
+  expect_equal(nrow(filtered), 63)
   expect_true(all(filtered$delivery_method == "ENH"))
 })
 
@@ -193,8 +193,8 @@ test_that("filter_DESRs filters by full term (1) correctly", {
   opt <- make_opt(pt = "1")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 59 base + 14 C-suffix rows (all part_term="1") = 73
-  expect_equal(nrow(filtered), 73)
+  # 59 base + 14 C-suffix + 3 EC-07 rows (all part_term="1") = 76
+  expect_equal(nrow(filtered), 76)
   expect_true(all(filtered$part_term == "1"))
 })
 
@@ -230,8 +230,8 @@ test_that("filter_DESRs filters by lower level correctly", {
   opt <- make_opt(level = "lower")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 49 base + 14 C-suffix rows (all level="lower") = 63
-  expect_equal(nrow(filtered), 63)
+  # 49 base + 14 C-suffix + 3 EC-07 rows (all level="lower") = 66
+  expect_equal(nrow(filtered), 66)
   expect_true(all(filtered$level == "lower"))
 })
 
@@ -347,10 +347,10 @@ test_that("filter_by_term handles term range correctly", {
 })
 
 test_that("filter_by_term covers all terms in fixture range", {
-  # All 4 test terms = all 99 rows (85 base + 14 C-suffix: EC-04, EC-05, EC-06)
+  # All 4 test terms = all 102 rows (85 base + 14 C-suffix + 3 EC-07)
   filtered <- filter_by_term(test_sections, "202010-202110", "term")
 
-  expect_equal(nrow(filtered), 99)
+  expect_equal(nrow(filtered), 102)
 })
 
 test_that("filter_by_term handles 'spring' keyword", {
@@ -370,10 +370,10 @@ test_that("filter_by_term handles 'summer' keyword", {
 })
 
 test_that("filter_by_term handles 'fall' keyword", {
-  # Fall = terms ending in 80: 202080 (21 base + 14 C-suffix: EC-04, EC-05, EC-06 = 35)
+  # Fall = terms ending in 80: 202080 (21 base + 14 C-suffix + 3 EC-07 = 38)
   filtered <- filter_by_term(test_sections, "fall", "term")
 
-  expect_equal(nrow(filtered), 35)
+  expect_equal(nrow(filtered), 38)
   expect_true(all(substring(as.character(filtered$term), 5, 6) == "80"))
 })
 

--- a/tests/testthat/test-low-enrollment.R
+++ b/tests/testthat/test-low-enrollment.R
@@ -25,8 +25,8 @@ test_that("filtering to status=A excludes cancelled sections", {
 
   expect_true(all(active$status    == "A"))
   expect_true(all(cancelled$status != "A"))
-  # 75 base + 14 C-suffix rows (EC-04:4, EC-05:4, EC-06:6, all status="A") = 89
-  expect_equal(nrow(active), 89)
+  # 75 base + 14 C-suffix + 3 EC-07 rows (all status="A") = 92
+  expect_equal(nrow(active), 92)
 })
 
 test_that("active sections include the zero-enrollment edge case", {
@@ -63,8 +63,8 @@ test_that("threshold filter with very high max returns all active sections", {
   all_active <- test_sections %>%
     filter(status == "A", total_enrl >= 0, total_enrl <= 9999)
 
-  # 75 base + 14 C-suffix rows = 89
-  expect_equal(nrow(all_active), 89)
+  # 75 base + 14 C-suffix + 3 EC-07 rows = 92
+  expect_equal(nrow(all_active), 92)
 })
 
 test_that("threshold filter that matches nothing returns zero rows", {

--- a/tests/testthat/test-summary-functions.R
+++ b/tests/testthat/test-summary-functions.R
@@ -114,6 +114,29 @@ test_that("course_enrl uses total_enrl (correct for combined C-suffix courses)",
   expect_equal(anth_2190c$n_sections,  1L)
 })
 
+test_that("course_enrl counts a multi-CRN internal group once (EC-07 / BIOL 2305)", {
+  # EC-07: 3 CRNs in internal group E7 — all kept by the home/internal filter,
+  # each carrying the group total (71) in total_enrl. A naive sum(total_enrl)
+  # would report 213; the correct course-level count is 71.
+  result <- get_course_section_counts(test_sections)
+
+  biol_2305 <- result %>% dplyr::filter(subject_course == "BIOL 2305")
+  expect_equal(nrow(biol_2305), 1)
+  expect_equal(biol_2305$n_sections,  3L)
+  expect_equal(biol_2305$course_enrl, 71)
+})
+
+test_that("course_enrl counts each internal group once for multi-group courses (EC-06 / BIOL 300C)", {
+  # EC-06: 2 internal groups (6G total=92, 62 total=138), 3 CRNs each — all 6
+  # rows kept. Correct: 92 + 138 = 230, not 3x92 + 3x138 = 690.
+  result <- get_course_section_counts(test_sections)
+
+  biol_300c <- result %>% dplyr::filter(subject_course == "BIOL 300C")
+  expect_equal(nrow(biol_300c), 1)
+  expect_equal(biol_300c$n_sections,  6L)
+  expect_equal(biol_300c$course_enrl, 230)
+})
+
 test_that("join pattern with coalesce works for downstream low-enrollment use", {
   counts <- get_course_section_counts(test_sections)
 


### PR DESCRIPTION
## The bug

Every section row in a crosslist group carries the **group's combined enrollment** in `total_enrl` (the parser sets it to `pmax(ENROLLED, XL_TOTAL_ENROLLMENT)`). So summing `total_enrl` over a group's rows multiply-counts it — once per section. Real symptom: **BIOL 2305** (three internal crosslist groups of 4 CRNs, every row carrying its group's ~96) reported `total_enrl = 1148` against 287 actually enrolled.

Two aggregation sites had it:

1. **`summarize_courses()`** summed `total_enrl` naively. `get_enrl()`'s existing "Pattern C normalization" was supposed to compensate, but it was **gated on `is_combined`** — and BIOL 2305 has no C-suffix (`is_combined = FALSE`), so non-combined internal crosslists slipped straight through.
2. **`get_course_section_counts()`** (dept-dashboard current stats) drops `partner` rows but keeps all `internal` rows, so multi-CRN internal groups were multiply-counted there too — despite being documented as "crosslist-deduplicated."

## The fix

A shared **`sum_xl_dedup_total()`** helper: within each aggregation cell, count each crosslist group's combined total **once** (max of its identical per-row values), plus own enrollment of non-crosslisted rows. Both sites use it. The `is_combined`-gated Pattern C normalization is **removed as superseded** — the dedup handles combined and non-combined internal groups uniformly, and section-level callers (`get_low_enrollment_courses`) still see raw per-row group totals.

**Cross-course groups keep their intended semantics**: each course's cell holds only its own rows of the group, so each course still reports the combined total including its partner (e.g. HIST 484 and HIST 584 both report their shared 11). The dedup only prevents counting a group twice *within* a cell.

Two correctness details worth reviewer attention:
- The dedup is computed **before** `enrolled` is reassigned inside `summarize()` — dplyr evaluates sequentially, so ordering it after would hand the helper a scalar instead of the raw vector.
- `summarize_courses` now fails loudly if `term`/`campus`/`crosslist_code` are missing (they scope the group key) instead of producing silently wrong crosslist math.

## Fixtures & tests

- New **EC-07** designed rows (`fixtures/designed_test_data.R`): BIOL 2305-shaped — internal crosslist, `is_combined = FALSE`, one group of 3 CRNs (enrolled 24/24/23), every row carrying the group total 71.
- Regression tests: EC-07 aggregates to **71, not 213**; EC-06 (BIOL 300C, two internal groups) to **230, not 690**; cross-course invariance (HIST 484/584 both report combined 11); same checks for `get_course_section_counts` (which had no test catching the 690 case).
- Whole-fixture count pins updated for the +3 rows / +71 enrolled in 202080, each with arithmetic comments.

## Verification

- Production data: BIOL 2305 / ABQ / Fall 2026 aggregated `total_enrl` = **287 = enrolled** (was 1148), 12 sections, through both `get_enrl` and `get_course_section_counts`.
- Full suite: `FAIL 0 | SKIP 38 | PASS 1753`.

## Downstream effect

`get_course_section_counts` feeds the dept-dashboard "current stats" cards — courses with multi-CRN internal crosslists will show **corrected (lower) enrollment numbers** there after this deploys. That's the bug being fixed, not a regression.

## Note

The AGENTS.md test-fixture docs describe the legacy `.qs` fixture pipeline that setup.R no longer loads (tests actually use `fixtures/designed_test_data.R`) — flagged as a separate cleanup task rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
