### PR TITLE
Institutionalize the DFW policy: never early drops, always late drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,16 @@ Defined in `R/lists/grades.R`. Use these constants for analytics; do not hardcod
 | `GRADES_PASS` | Outcomes that count as passing for analytics (C or better, CR, P, S, retake variants) |
 | `passing_grades` | Grades that earn credit hours — intentionally excludes D grades; do not use for DFW analytics |
 
+### CEDAR-wide DFW policy
+
+**DFW = D/F/W final grades (`GRADES_DFW`) plus late drops (`STATUS_DROP_LATE`). Early drops (`STATUS_DROP_EARLY`) are NEVER DFW.** This is the standard IR definition and is not negotiable per-cone:
+
+- A **late drop** (DG/DW — after the deadline) is the registration-status form of a W. Most withdrawals in the data post as late-drop status rows, *not* as W grades under a registered status, so any DFW computation that looks only at grades undercounts W.
+- An **early drop** (DR — before the deadline) posts no grade. It is registration churn (schedule shuffling, melt), not an academic outcome. Counting it as DFW inflates failure rates with non-failures.
+- Early drops are still analytically interesting — track them **separately** (`dr_early`, `n_early_drop`, early-drop rates in `get_course_outcome_rates()`), never folded into DFW.
+
+The canonical classifier is **`classify_enrollment_outcomes()` in `R/trunk/utils.R`** — used by the `cedar_grades` pre-computation (`transform-to-cedar.R`) and by `classify_outcomes()` (`cones/stopout.R`). Do not write a new inline pass/DFW classification; call or extend the canonical one. The legacy gradebook `dfw_pct` (`calculate_dfw()`) already follows this policy: `(failed + late_dropped) / (passed + failed + late_dropped)`, early drops excluded.
+
 ---
 
 ## Cone Architecture

--- a/R/cones/stopout.R
+++ b/R/cones/stopout.R
@@ -337,13 +337,15 @@ get_dfw_rates <- function(students, population, opt = list(), cedar_grades = NUL
 
 #' Classify Student Enrollment Records as Pass or DFW
 #'
-#' Takes graded enrollment records and labels each as `"pass"`, `"dfw"`, or
-#' `"ungraded"`. Ungraded records (incomplete, audit, no record) are dropped
-#' from the result — they provide no signal for stop-out analysis.
+#' Takes enrollment records and labels each as `"pass"` or `"dfw"` using the
+#' canonical CEDAR classification (`classify_enrollment_outcomes()` in
+#' trunk/utils.R — see the "CEDAR-wide DFW policy" note in AGENTS.md).
+#' Ungraded records (incomplete, audit, no record) are dropped — they provide
+#' no signal for stop-out analysis.
 #'
-#' Considers only registered students (registration_status_code RE, RS, RR).
-#' Early drops (DR) are treated as DFW — a student who dropped before the
-#' deadline is still a non-completion.
+#' DFW covers D/F/W final grades plus late drops (`STATUS_DROP_LATE`).
+#' Early drops (`STATUS_DROP_EARLY`) are excluded entirely: a drop before the
+#' deadline posts no grade and is not an academic outcome.
 #'
 #' @param students Data frame. The `cedar_students` table.
 #'
@@ -354,20 +356,9 @@ get_dfw_rates <- function(students, population, opt = list(), cedar_grades = NUL
 classify_outcomes <- function(students) {
 
   students %>%
-    filter(
-      registration_status_code %in% c(STATUS_REGISTERED, STATUS_DROP_EARLY)
-    ) %>%
     select(student_id, term, subject_course, final_grade, registration_status_code) %>%
     distinct() %>%
-    mutate(
-      outcome = case_when(
-        registration_status_code %in% STATUS_DROP_EARLY ~ "dfw",
-        final_grade %in% GRADES_DFW                    ~ "dfw",
-        final_grade %in% GRADES_PASS                   ~ "pass",
-        TRUE                                            ~ NA_character_
-      )
-    ) %>%
-    filter(!is.na(outcome)) %>%
+    classify_enrollment_outcomes() %>%
     select(student_id, term, subject_course, outcome)
 }
 

--- a/R/data-parsers/transform-to-cedar.R
+++ b/R/data-parsers/transform-to-cedar.R
@@ -693,17 +693,26 @@ transform_students <- function(class_lists, data_dir, ext, maps) {
   # ── cedar_grades ─────────────────────────────────────────────────────────
   # Built from pre-dedup cedar_students (CRN-level) so topics courses sharing
   # a subject_course code are preserved as separate rows.
+  # Outcome classification is the canonical CEDAR pass/DFW policy from
+  # classify_enrollment_outcomes() (trunk/utils.R): DFW = D/F/W grades plus
+  # late drops; early drops are NEVER DFW (see AGENTS.md, "CEDAR-wide DFW policy").
   message("  Computing cedar_grades (pre-classified outcomes, CRN-level dedup)...")
+  # classify first (it restricts to registered + late-drop rows), THEN dedup —
+  # otherwise an excluded row (e.g. an early drop) could win the CRN dedup and
+  # shadow the student's real outcome row.
+  #
+  # Dedup key MUST include term: Banner recycles CRNs across terms, so a retake
+  # of a course under a recycled CRN is a distinct outcome, not a duplicate
+  # (~20k student-crn pairs span multiple terms in real data).
+  #
+  # Tie-break within (student, crn, term): a late-drop row wins over a
+  # coexisting registered row — the withdrawal is the outcome of record.
+  # arrange() makes the previously data-order-dependent choice deterministic.
   cedar_grades_tbl <- cedar_students %>%
-    filter(registration_status_code %in% c(STATUS_REGISTERED, STATUS_DROP_EARLY)) %>%
-    distinct(student_id, crn, .keep_all = TRUE) %>%
-    mutate(outcome = case_when(
-      registration_status_code %in% STATUS_DROP_EARLY ~ "dfw",
-      final_grade %in% GRADES_DFW                     ~ "dfw",
-      final_grade %in% GRADES_PASS                    ~ "pass",
-      TRUE                                             ~ NA_character_
-    )) %>%
-    filter(!is.na(outcome)) %>%
+    classify_enrollment_outcomes() %>%
+    arrange(student_id, term, crn,
+            desc(registration_status_code %in% STATUS_DROP_LATE)) %>%
+    distinct(student_id, crn, term, .keep_all = TRUE) %>%
     select(student_id, term, subject_course, outcome, campus, level)
   grades_meta <- save_cedar_file(cedar_grades_tbl, "grades", data_dir, ext)
   message("  ✅ cedar_grades: ", nrow(cedar_grades_tbl), " rows, ", ncol(cedar_grades_tbl), " columns")

--- a/R/modules/pathways.R
+++ b/R/modules/pathways.R
@@ -934,10 +934,11 @@ methodology_panel_content <- function() {
         tags$th("classified as")
       )),
       tags$tbody(
-        tags$tr(tags$td("DR (early drop)"),tags$td("any"),tags$td("dfw — non-completion regardless of grade",class="hl")),
+        tags$tr(tags$td("DG / DW (late drop)"),tags$td("any"),tags$td("dfw — this is the W in DFW; most withdrawals post as late-drop status rows",class="hl")),
         tags$tr(tags$td("RE / RS / RR"),tags$td("D, D+, D–, F, W, RD, RF"),tags$td("dfw",class="hl")),
         tags$tr(tags$td("RE / RS / RR"),tags$td("A–C, CR, P, S, RA–RC, RCR"),tags$td("pass",class="hl")),
         tags$tr(tags$td("RE / RS / RR"),tags$td("I, AUD, NR, or other"),tags$td("excluded — ungraded, no signal")),
+        tags$tr(tags$td("DR (early drop)"),tags$td("any"),tags$td("excluded — a drop before the deadline posts no grade; registration churn, not an academic outcome")),
         tags$tr(tags$td("WL / other"),tags$td("any"),tags$td("excluded"))
       )
     ),

--- a/R/trunk/utils.R
+++ b/R/trunk/utils.R
@@ -652,6 +652,47 @@ classify_grades <- function(students) {
 }
 
 
+#' Canonical pass/DFW classification of enrollment records
+#'
+#' The single source of truth for turning class-list rows into pass/DFW
+#' outcomes (see "CEDAR-wide DFW policy" in AGENTS.md). Used by the
+#' cedar_grades pre-computation in transform-to-cedar.R and by
+#' classify_outcomes() in cones/stopout.R — do not re-implement this
+#' classification inline elsewhere.
+#'
+#' Policy:
+#' - DFW = D/F/W final grades (GRADES_DFW) plus late drops (STATUS_DROP_LATE,
+#'   the registration-status form of a W — most W outcomes are recorded as
+#'   DG/DW status rows, not as W grades under a registered status).
+#' - Early drops (STATUS_DROP_EARLY) are NEVER DFW. A drop before the deadline
+#'   posts no grade; it is registration churn, not an academic outcome. Early
+#'   drops are tracked separately (dr_early, n_early_drop, early-drop rates).
+#' - Rows that are neither registered nor late-dropped, and registered rows
+#'   with no classifiable grade (incomplete, audit, blank), are excluded.
+#'
+#' Requires lists/grades.R and lists/status_codes.R to be sourced.
+#'
+#' @param students A tibble with registration_status_code and final_grade.
+#' @return The input rows restricted to registered + late-drop records that
+#'   have a classifiable outcome, with an added `outcome` column
+#'   ("pass" or "dfw"). All other input columns are preserved.
+classify_enrollment_outcomes <- function(students) {
+  students %>%
+    dplyr::filter(
+      registration_status_code %in% c(STATUS_REGISTERED, STATUS_DROP_LATE)
+    ) %>%
+    dplyr::mutate(
+      outcome = dplyr::case_when(
+        registration_status_code %in% STATUS_DROP_LATE ~ "dfw",
+        final_grade %in% GRADES_DFW                    ~ "dfw",
+        final_grade %in% GRADES_PASS                   ~ "pass",
+        TRUE                                            ~ NA_character_
+      )
+    ) %>%
+    dplyr::filter(!is.na(outcome))
+}
+
+
 # ---------------------------------------------------------------------------
 # Categorical color mapping
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test-stopout.R
+++ b/tests/testthat/test-stopout.R
@@ -15,25 +15,27 @@ context("Stopout: Stop-Out Analysis")
 # classify_outcomes()
 # =============================================================================
 #
-# Test data:
+# Test data (canonical DFW policy — see AGENTS.md "CEDAR-wide DFW policy"):
 #   S001 — registered, got A         → pass
 #   S002 — registered, got F         → dfw
 #   S003 — registered, got W         → dfw
 #   S004 — registered, got D-        → dfw
 #   S005 — registered, got C         → pass
-#   S006 — early drop (DR), any grade → dfw
+#   S006 — early drop (DR)           → EXCLUDED (early drops are never DFW)
 #   S007 — registered, got I (incomplete) → excluded (ungraded)
 #   S008 — registered, got AUD       → excluded (ungraded)
 #   S009 — registered, got RB (repeat pass) → pass
 #   S010 — registered, got RF (repeat fail) → dfw
+#   S011 — late drop (DW), grade W   → dfw (the W in DFW)
+#   S012 — late drop (DG), blank grade → dfw (status alone carries the W)
 
 make_grade_data <- function() {
   tibble(
-    student_id               = paste0("S", sprintf("%03d", 1:10)),
-    term                     = rep(202510, 10),
-    subject_course           = rep("BIOL 2310", 10),
-    final_grade              = c("A", "F", "W", "D-", "C", "W", "I", "AUD", "RB", "RF"),
-    registration_status_code = c("RE", "RE", "RE", "RE", "RE", "DR", "RE", "RE", "RE", "RE")
+    student_id               = paste0("S", sprintf("%03d", 1:12)),
+    term                     = rep(202510, 12),
+    subject_course           = rep("BIOL 2310", 12),
+    final_grade              = c("A", "F", "W", "D-", "C", "W", "I", "AUD", "RB", "RF", "W", ""),
+    registration_status_code = c("RE", "RE", "RE", "RE", "RE", "DR", "RE", "RE", "RE", "RE", "DW", "DG")
   )
 }
 
@@ -70,12 +72,20 @@ test_that("classify_outcomes correctly labels DFW grades", {
   expect_true("S010" %in% dfw_ids)
 })
 
-test_that("classify_outcomes treats early drops (DR) as DFW", {
+test_that("classify_outcomes excludes early drops (DR) entirely", {
+  # CEDAR-wide DFW policy: an early drop posts no grade and is never DFW.
   result <- classify_outcomes(make_grade_data())
-  # S006 has registration_status_code = DR
-  s006 <- result %>% filter(student_id == "S006")
-  expect_equal(nrow(s006), 1)
-  expect_equal(s006$outcome, "dfw")
+  expect_false("S006" %in% result$student_id)
+})
+
+test_that("classify_outcomes counts late drops (DG/DW) as DFW", {
+  # Late drops are the registration-status form of a W — most withdrawals
+  # post as DG/DW status rows, not as W grades under a registered status.
+  result <- classify_outcomes(make_grade_data())
+  s011 <- result %>% filter(student_id == "S011")  # DW + W grade
+  s012 <- result %>% filter(student_id == "S012")  # DG + blank grade
+  expect_equal(s011$outcome, "dfw")
+  expect_equal(s012$outcome, "dfw")
 })
 
 test_that("classify_outcomes excludes ungraded records", {


### PR DESCRIPTION
## Problem

CEDAR had three coexisting DFW definitions. `course-attempts.R` and the legacy gradebook were already correct — early drops tracked separately, late drops counted as the W. But the stop-out pipeline (Pathways → Roadblocks) had it backwards on **both** sides:

- **Early drops (DR) counted as DFW.** Production DR rows carry essentially no grades (~153k blank/NA) — they're registration churn, not academic outcomes. Counting them inflates failure rates with non-failures.
- **Most real withdrawals were missed.** W outcomes overwhelmingly post as **late-drop status rows** (DG: 51k, DW: 18k), not as W grades under a registered status (RE/RS: ~34k). The old filter (`registered + DR`) never admitted DG/DW rows, so two-thirds of actual Ws were invisible to the stop-out analysis.

## The policy (now canonical)

**DFW = D/F/W final grades (`GRADES_DFW`) plus late drops (`STATUS_DROP_LATE`). Early drops (`STATUS_DROP_EARLY`) are never DFW.** This matches standard IR practice and what the rest of CEDAR already did.

- Single source of truth: **`classify_enrollment_outcomes()`** in `R/trunk/utils.R`. Both consumers — `classify_outcomes()` (stopout cone) and the `cedar_grades` pre-computation (`transform-to-cedar.R`) — now delegate to it.
- **AGENTS.md** gains a "CEDAR-wide DFW policy" section under Grade Constants: the definition, the reasoning, the canonical helper, and the instruction to never re-implement pass/DFW classification inline.
- Pathways **Methodology** outcome table updated to match (DR row → excluded, with rationale; DG/DW row added as the W).

## Two latent dedup bugs fixed in the same block

While rewriting the `cedar_grades` computation:

1. **Dedup key lacked `term`.** Banner recycles CRNs across terms (23k of 38k CRNs appear in >1 term); `distinct(student_id, crn)` was collapsing ~20k student-CRN pairs that span terms — silently dropping legitimate retake outcomes.
2. **Order-dependent tie-break.** A student with contradictory same-CRN rows (e.g. RE + DW) got whichever row happened to come first in the data. Now deterministic: the late-drop row is the outcome of record.

## Effect on data

Local `shared-data/cedar_grades.qs` regenerated with the new logic (the droplet regenerates on its next `update-data.sh` run — until then production Roadblocks serves the old classification):

| | rows | dfw | pass |
|---|---|---|---|
| Old | 1,490,393 | 277,210 | 1,213,183 |
| New | 1,395,153 | **185,941** | 1,209,212 |

DFW down ~33% (early drops out, real late-drop Ws in); pass nearly unchanged; ~16k retake records recovered by the term-scoped dedup. **Roadblocks DFW and stop-out numbers will shift — that is the correction, not a regression.**

## Tests

`classify_outcomes` unit tests updated to pin the policy: DR excluded entirely; DW + W grade → dfw; DG + blank grade → dfw (status alone carries the W). Full suite: `FAIL 0 | SKIP 38 | PASS 1739`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
