### PR TITLE
Share one observation-window guard across the Pathways analyses

### DIFF
--- a/R/branches/pathways.R
+++ b/R/branches/pathways.R
@@ -21,6 +21,33 @@ pathways_level_filter <- function(level_choice) {
 }
 
 
+#' Latest term whose outcomes are fully observable
+#'
+#' Right-censoring guard shared by the Pathways analyses: an outcome measured
+#' by "what happened in later terms" (returned next term, later took course B,
+#' later entered the major) is only observable for records with enough
+#' complete regular terms after them. Records after this boundary would all
+#' look like non-returns / non-entries simply because the data ends.
+#'
+#' @param latest_complete_term Integer term code of the last complete data
+#'   term (typically `subtract_term(cedar_current_term)`).
+#' @param follow_up_terms Integer. How many complete regular (fall/spring)
+#'   terms of follow-up the analysis needs. 1 for next-term outcomes
+#'   (stop-out), the A-to-B gap for course pairs, etc.
+#' @return Integer term code: the latest term with full follow-up. NULL if
+#'   latest_complete_term is NULL/NA.
+#' @keywords internal
+pathways_observation_boundary <- function(latest_complete_term,
+                                          follow_up_terms = 1L) {
+  if (is.null(latest_complete_term) || is.na(latest_complete_term)) return(NULL)
+  boundary <- as.integer(latest_complete_term)
+  for (i in seq_len(max(0L, as.integer(follow_up_terms)))) {
+    boundary <- subtract_term(boundary)
+  }
+  boundary
+}
+
+
 #' Apply Pathways analysis term and population membership window
 #'
 #' @param data Data frame with student_id and term columns.

--- a/R/cones/pathway.R
+++ b/R/cones/pathway.R
@@ -644,6 +644,12 @@ plot_curriculum_map <- function(timing_data, opt = list()) {
 #'       be meaningfully sequential).}
 #'     \item{`subject_code`}{Character vector. Restrict to courses in these
 #'       subjects. Optional.}
+#'     \item{`censor_term`}{Integer term code of the last complete data term.
+#'       When supplied, A-side enrollments (and the `pct_a_to_b` denominator)
+#'       are restricted to terms with `max_term_gap` complete regular terms of
+#'       follow-up, so recently-taken courses don't show deflated follow-on
+#'       rates purely because the data ends (right-censoring). Optional;
+#'       NULL preserves uncensored behavior.}
 #'   }
 #'
 #' @return Data frame sorted by `n_students` descending, with columns:
@@ -706,18 +712,39 @@ get_course_pairs <- function(students, population, opt = list()) {
   # Same logic as get_course_timing: summer doesn't advance the counter.
   enrolled <- assign_relative_terms(enrolled, include_summer = FALSE)
 
+  # --- Step 2b: Observation-window censoring (A side only) ---
+  # An A-enrollment only gets a fair chance to show a follow-on B if the data
+  # contains max_term_gap complete regular terms after it. Without this,
+  # recently-taken courses drag pct_a_to_b down purely because the data ends
+  # (right-censoring), not because students skip the follow-on.
+  # opt$censor_term = last complete data term (the Pathways module passes it);
+  # A-side rows — and the pct denominator — are restricted to calendar terms
+  # with a full follow-up window. B-side rows are never censored.
+  # NULL censor_term (e.g. standalone RStudio use) preserves old behavior.
+  a_pool <- enrolled
+  a_boundary <- NULL
+  if (!is.null(opt$censor_term) && !is.na(opt$censor_term)) {
+    a_boundary <- pathways_observation_boundary(opt$censor_term, max_term_gap)
+    a_pool <- a_pool %>% filter(term <= a_boundary)
+    message("[pathway.R] Censoring A-side enrollments after ", a_boundary,
+            " (", max_term_gap, " regular terms of follow-up required; data through ",
+            opt$censor_term, ").")
+  }
+
   # --- Step 3: Pre-filter to qualifying course_a candidates before the self-join ---
   # This is the key scaling fix. A full enrolled × enrolled self-join is O(N²) in
   # enrollment rows. Computing n_took_a first and restricting the left side to
   # qualifying courses reduces the left factor significantly — typically 5–10× for
   # large populations where most courses fall below the min_n threshold.
   # The right side (course_b) stays unrestricted: any course can follow a qualifying A.
-  n_took_a <- enrolled %>%
+  # n_took_a comes from the censored A pool so the pct_a_to_b denominator matches
+  # the numerator's observation window.
+  n_took_a <- a_pool %>%
     group_by(subject_course) %>%
     summarize(n_took_a = n_distinct(student_id), .groups = "drop") %>%
     filter(n_took_a >= min_n)
 
-  enrolled_a <- enrolled %>%
+  enrolled_a <- a_pool %>%
     filter(subject_course %in% n_took_a$subject_course)
 
   message("[pathway.R] Pair search: ", nrow(enrolled_a), " A-side rows × ",
@@ -767,7 +794,8 @@ get_course_pairs <- function(students, population, opt = list()) {
     n_b_rows     = nrow(enrolled),
     min_n        = min_n,
     min_pair_n   = min_pair_n,
-    n_pairs      = nrow(result)
+    n_pairs      = nrow(result),
+    a_boundary   = a_boundary
   )
   return(result)
 }

--- a/R/modules/pathways.R
+++ b/R/modules/pathways.R
@@ -559,7 +559,7 @@ pathwaysUI <- function(id, campus_choices, program_choices = character(),
             filter_scope_stripe(div(class = "subtab-scope", uiOutput(ns("cp_meta"))))
           ),
           subtab_intro("Course Pairs",
-            "surfaces common A→B course sequences: of students who took course A, what share later took course B? Useful for spotting de-facto prerequisites and popular follow-ons. Pairs more than the max term gap apart are excluded, and non-ongoing students count only through their last focal term."),
+            "surfaces common A→B course sequences: of students who took course A, what share later took course B? Useful for spotting de-facto prerequisites and popular follow-ons. Pairs more than the max term gap apart are excluded, and non-ongoing students count only through their last focal term. Course A enrollments are only counted where the data holds the full follow-up window, so recent terms don't deflate the rates."),
           reactable::reactableOutput(ns("cp_table"))
         ),
 
@@ -623,7 +623,9 @@ pathwaysUI <- function(id, campus_choices, program_choices = character(),
             " in those focal-subject courses — it is ", tags$em("not"),
             " limited by the Population scope dropdown. A student counts as entering only when their first ",
             tags$strong("major or pre-major"),
-            " record in this department appears after the course term. Same-term department records are excluded because the course did not clearly precede entry. The ",
+            " record in this department appears after the course term. Same-term department records are excluded because the course did not clearly precede entry. By default the ",
+            tags$strong("To term"),
+            " ends one regular term before the newest complete term — students enrolled more recently have had no time to enter the department, so including them deflates Entry %. The ",
             tags$em("Courses Before Major Entry"),
             " heatmaps use a different scope: selected-population students only."
           ),
@@ -985,10 +987,13 @@ methodology_panel_content <- function() {
     div(class = "alert-box alert-box--watch",
       tags$strong("⚠ Known anomalies to watch for:"),
       tags$ul(class = "mt-1",
-        tags$li("The module caps Pathways analyses at the term before the current term. If source
-                  data or precomputed next-term lookups do not include a visible following fall/spring
-                  for the latest analyzed term, recently active courses can still show inflated
-                  stop-out rates."),
+        tags$li("Observation window: analyses whose outcome lives in later terms (stop-out,
+                  course pairs, course-to-major entry) exclude records too recent to have a
+                  complete follow-up window — stop-out caps outcome terms one regular term
+                  before the last complete term, course pairs require the full max-gap window
+                  on the A side, and the course-to-major To term defaults to the same boundary.
+                  Without this, recent records would all read as non-returns / non-entries
+                  simply because the data ends."),
         tags$li(HTML("Rows where <code>pop_n_dfw</code> is very small (1–4) produce
                        unreliable rates. The Min group DFW students filter (default 5) removes these.")),
         tags$li("The baseline is ALL non-group students in the same courses."),
@@ -2319,11 +2324,27 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
       showNotification(status_message, type = "warning", duration = NULL, id = "so_loading")
       timer <- start_report_timer("pathways-stopouts")
 
-      # Evaluate cedar_grades once; use it to decide whether the expensive
-      # filtered_students() fallback is needed. get_stopout() only touches
-      # `students` when cedar_grades is absent — avoid the full-table scan otherwise.
-      so_grades   <- filtered_cedar_grades()
-      so_students <- if (!is.null(so_grades) && nrow(so_grades) > 0) NULL else filtered_students()
+      # Observation-window guard: a term's stop-out is only observable once the
+      # FOLLOWING regular term is complete. Cap outcome terms at the shared
+      # boundary so records with no visible next term don't inflate stop-out
+      # rates (they would all read as stopped out). Next-term RETURN detection
+      # is unaffected — it uses the full-history cedar_next_term lookup.
+      so_boundary <- pathways_observation_boundary(analysis_through, 1L)
+
+      # Evaluate cedar_grades once (boundary-capped); use it to decide whether
+      # the expensive filtered_students() fallback is needed. get_stopout() only
+      # touches `students` when cedar_grades is absent — avoid the scan otherwise.
+      so_grades <- filtered_cedar_grades()
+      if (!is.null(so_grades) && !is.null(so_boundary)) {
+        so_grades <- dplyr::filter(so_grades, term <= so_boundary)
+      }
+      so_students <- if (!is.null(so_grades) && nrow(so_grades) > 0) {
+        NULL
+      } else {
+        s <- filtered_students()
+        if (!is.null(so_boundary)) s <- dplyr::filter(s, term <= so_boundary)
+        s
+      }
 
       result <- tryCatch({
         get_stopout(
@@ -2352,23 +2373,24 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
 
     output$so_recent_term_warn <- renderUI({
       req(so_data())
-      tr <- so_data()$term_range
-      if (any(is.na(tr))) return(NULL)
-      max_data_term <- tr[2]
-      # Warn when the most recent analyzed term equals the latest term in the data.
-      # All students enrolled in that term have no visible next term, so they
-      # all appear as stopped out — this inflates stop-out rates for recent courses.
-      latest_global <- max(programs$term, na.rm = TRUE)
-      if (max_data_term >= latest_global) {
-        div(
+      so_boundary <- pathways_observation_boundary(analysis_through, 1L)
+      if (is.null(so_boundary)) {
+        # Boundary could not be derived (no cedar_current_term) — censored
+        # recent terms may be included, so fall back to the old warning.
+        return(div(
           class = "alert alert-warning alert-compact",
           tags$strong("⚠ Most-recent-term bias: "),
-          "The data extends through ", fmt_term(latest_global), ". ",
-          "Students enrolled in that term have no visible next term, so they all appear as stopped out. ",
-          "Stop-out rates for recently active courses are inflated. ",
-          "To exclude this effect, set a Term filter that ends one term earlier."
-        )
+          "Students enrolled in the latest data term have no visible next term, ",
+          "so they all appear as stopped out — rates for recently active courses are inflated."
+        ))
       }
+      div(
+        class = "alert alert-info alert-compact",
+        tags$strong("Observation window: "),
+        "outcomes through ", fmt_term(so_boundary),
+        ". Later terms are excluded because their next regular term is not yet ",
+        "complete — students there would all appear as stopped out regardless of behavior."
+      )
     })
 
     output$so_meta <- renderUI({
@@ -2745,7 +2767,11 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
       opt <- list(
         min_n        = as.integer(input$cp_min_n),
         min_pair_n   = as.integer(input$cp_min_pair),
-        max_term_gap = as.integer(input$cp_max_gap)
+        max_term_gap = as.integer(input$cp_max_gap),
+        # Shared observation-window guard: A-side enrollments need max_term_gap
+        # complete regular terms of follow-up or their follow-on rates are
+        # deflated by the data ending (right-censoring).
+        censor_term  = analysis_through
       )
       opt$level <- pathways_level_filter(input$cp_level)
       if (length(input$cp_subject) > 0) opt$subject_code <- input$cp_subject
@@ -2833,15 +2859,20 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
       d    <- cp_data()
       meta <- attr(d, "pair_meta")
       if (is.null(meta)) return(NULL)
+      boundary_note <- if (!is.null(meta$a_boundary)) {
+        sprintf(" Course A enrollments counted through %s so every A-taker has the full %d-term follow-up window in the data.",
+                fmt_term(meta$a_boundary), as.integer(input$cp_max_gap))
+      } else ""
       tags$p(
         sprintf(
-          "%d qualifying course%s (taken by ≥%d students). Searched %s A-side × %s B-side enrollment records. %d pair%s found (taken by ≥%d students each).",
+          "%d qualifying course%s (taken by ≥%d students). Searched %s A-side × %s B-side enrollment records. %d pair%s found (taken by ≥%d students each).%s",
           meta$n_qualifying, if (meta$n_qualifying == 1) "" else "s",
           meta$min_n,
           format(meta$n_a_rows, big.mark = ","),
           format(meta$n_b_rows, big.mark = ","),
           meta$n_pairs, if (meta$n_pairs == 1) "" else "s",
-          meta$min_pair_n
+          meta$min_pair_n,
+          boundary_note
         ),
         class = "text-muted-sm"
       )
@@ -4186,13 +4217,22 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
         to_terms,
         vapply(to_terms, .term_label, FUN.VALUE = character(1))
       )
+      # Default To term = the shared observation boundary (last term with a
+      # complete regular term of follow-up), not the newest term: a student
+      # enrolled last term has had no time to "later enter" the department, so
+      # including censored terms deflates Entry %. Users can still pick a more
+      # recent term explicitly.
+      ge_boundary <- pathways_observation_boundary(analysis_through, 1L)
+      ge_to_default <- if (!is.null(ge_boundary) && any(to_terms <= ge_boundary)) {
+        max(to_terms[to_terms <= ge_boundary])
+      } else if (length(to_terms)) max(to_terms) else NULL
       updateSelectizeInput(session, "ge_from_term",
                            choices  = from_labels,
                            selected = if (length(from_terms)) min(from_terms) else NULL,
                            server   = TRUE)
       updateSelectizeInput(session, "ge_to_term",
                            choices  = to_labels,
-                           selected = if (length(to_terms)) max(to_terms) else NULL,
+                           selected = ge_to_default,
                            server   = TRUE)
     })
 

--- a/tests/testthat/test-pathway.R
+++ b/tests/testthat/test-pathway.R
@@ -689,3 +689,50 @@ test_that("get_event_adjacent_courses errors on invalid event argument", {
     "entry.*exit"
   )
 })
+
+
+# =============================================================================
+# get_course_pairs() observation-window censoring (opt$censor_term)
+# =============================================================================
+# Data terms: 202410, 202480, 202510. With censor_term = 202510 (last complete
+# term) and max_term_gap = 2, the A-side boundary is 202410 — so CHEM 1215
+# rows (all 202410) stay on the A side, but BIOL 2310 rows (202480) are too
+# recent to have a full 2-term follow-up window and drop off the A side.
+
+test_that("get_course_pairs censor_term drops A-side rows without a full follow-up window", {
+  result <- get_course_pairs(
+    make_pathway_students(), make_pathway_population(),
+    opt = list(min_n = 1, min_pair_n = 1, max_term_gap = 2, censor_term = 202510L)
+  )
+
+  # CHEM 1215 pairs unaffected (A rows at 202410 have the full window)
+  chem_biol <- result %>% filter(course_a == "CHEM 1215", course_b == "BIOL 2310")
+  expect_equal(chem_biol$n_students, 4)
+  expect_equal(chem_biol$n_took_a,   4)
+
+  # BIOL 2310 (202480) has only one complete follow-up term — excluded as A
+  expect_false("BIOL 2310" %in% result$course_a)
+
+  # Boundary recorded in metadata for scope display
+  expect_equal(attr(result, "pair_meta")$a_boundary, 202410L)
+})
+
+test_that("get_course_pairs censor_term with a 1-term gap keeps BIOL as course A", {
+  # gap = 1 → boundary = 202480; BIOL 2310 rows (202480) now have full follow-up.
+  result <- get_course_pairs(
+    make_pathway_students(), make_pathway_population(),
+    opt = list(min_n = 1, min_pair_n = 1, max_term_gap = 1, censor_term = 202510L)
+  )
+  biol_engl <- result %>% filter(course_a == "BIOL 2310", course_b == "ENGL 1110")
+  expect_equal(biol_engl$n_students, 4)
+  expect_equal(biol_engl$n_took_a,   5)
+})
+
+test_that("get_course_pairs without censor_term preserves uncensored behavior", {
+  result <- get_course_pairs(
+    make_pathway_students(), make_pathway_population(),
+    opt = list(min_n = 1, min_pair_n = 1, max_term_gap = 2)
+  )
+  expect_true("BIOL 2310" %in% result$course_a)
+  expect_null(attr(result, "pair_meta")$a_boundary)
+})

--- a/tests/testthat/test-pathways-helpers.R
+++ b/tests/testthat/test-pathways-helpers.R
@@ -69,3 +69,20 @@ test_that("resolve_pathways_gen_ed_courses keeps only focal subject courses", {
   expect_true(length(courses) > 0)
   expect_true(all(sub(" .*", "", courses) %in% focal_subjects))
 })
+
+
+test_that("pathways_observation_boundary walks back complete regular terms", {
+  # One term of follow-up: Fall 2025 outcomes need Spring 2026 complete.
+  expect_equal(pathways_observation_boundary(202610L, 1L), 202580L)
+  # Two terms of follow-up (e.g. course-pairs max gap = 2).
+  expect_equal(pathways_observation_boundary(202510L, 2L), 202410L)
+  # Summer input steps back to the prior regular term.
+  expect_equal(pathways_observation_boundary(202560L, 1L), 202510L)
+  # Zero follow-up = the boundary is the last complete term itself.
+  expect_equal(pathways_observation_boundary(202510L, 0L), 202510L)
+})
+
+test_that("pathways_observation_boundary returns NULL when the anchor is unknown", {
+  expect_null(pathways_observation_boundary(NULL, 1L))
+  expect_null(pathways_observation_boundary(NA_integer_, 1L))
+})


### PR DESCRIPTION
## Problem (from the Pathways audit)

Analyses whose outcome lives in **later terms** are right-censored at the end of the data, and the tab handled that inconsistently:

- **Roadblocks** warned about most-recent-term bias — but the inflated rows still participated in the Impact ranking.
- **Course Pairs** had the same bias, unwarned: a student who took course A last term has had no chance to take B yet, so `pct_a_to_b` was deflated for recently-taken courses.
- **Course to Major** defaulted its term range to the newest term, so recently enrolled students — who have had no time to "later enter" the department — deflated Entry %.

## Fix: one shared guard

**`pathways_observation_boundary(latest_complete_term, follow_up_terms)`** in `branches/pathways.R`: the latest term with N complete regular (fall/spring) terms of follow-up after it. Applied by default in all three places:

| Analysis | Follow-up needed | Default behavior now |
|---|---|---|
| Roadblocks (stop-out) | 1 complete next term | Outcome terms capped at the boundary; the warning becomes an informational "Observation window: outcomes through X" note |
| Course Pairs | the full `max_term_gap` window | A-side rows **and the `pct_a_to_b` denominator** restricted to terms with complete follow-up (B side never censored); boundary shown in the scope stripe |
| Course to Major | 1 complete term | "To term" selector defaults to the boundary instead of the newest term (still user-overridable) |

Details worth reviewer attention:

- **Roadblocks return detection is unaffected** — it still uses the full-history `cedar_next_term` lookup, so a boundary-term student who returned in the newest term is correctly seen as returning. Only the *outcome* terms are capped.
- The grades-vs-students fallback decision in the module happens **after** the boundary filter (an empty-after-filter grades table now correctly falls back to the students path).
- `get_course_pairs(opt$censor_term = NULL)` preserves the old uncensored behavior for standalone/RStudio use, and the old Roadblocks warning survives as a fallback when the boundary can't be derived (no `cedar_current_term`).
- Methodology panel rewritten to describe the shared window.

## Tests

- Boundary arithmetic: regular-term walk-back, summer anchor, zero follow-up, NULL/NA → NULL.
- Pairs censoring: A-side exclusion at gap=2 vs inclusion at gap=1 (pinned counts), denominator matches the censored pool, boundary recorded in `pair_meta`, uncensored fallback intact.
- Full suite: `FAIL 0 | SKIP 38 | PASS 1768`.

## What users will see

With current config (current term = Summer 2026, last complete term = Spring 2026): Roadblocks analyzes outcomes through **Fall 2025**; Course Pairs counts A-enrollments only where the follow-up window fits; Course to Major defaults its To term to **Fall 2025**. Row counts shrink slightly versus before — those rows were the statistically meaningless ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
