### PR TITLE
Pathways audit refinements: honest excess_gap, pairs lift, instructor anchoring

### DIFF
--- a/R/cones/gen-ed-conversion.R
+++ b/R/cones/gen-ed-conversion.R
@@ -495,6 +495,31 @@ get_course_major_associations <- function(students, programs, opt = list()) {
     return(NULL)
   }
 
+  # Course-level anchor for instructor-split tables. An instructor's raw
+  # Entry % is confounded by which course (and which sections of it) they
+  # teach — fall gateway vs. spring service sections, campus mix, and student
+  # self-selection all move entry rates BETWEEN courses. Comparing each
+  # instructor against their own course's overall rate removes the
+  # between-course component:
+  #   course_entry_pct     — the whole course's entry rate (all instructors,
+  #                          all eligible students, pre-min_n filtering)
+  #   entry_pct_vs_course  — this group's rate minus the course rate;
+  #                          positive = above the course's own average
+  # Still descriptive (within-course selection remains), but far harder to
+  # misread as a cross-course instructor league table.
+  if (all(c("subject_course", "instructor_name") %in% group_cols)) {
+    course_rates <- enriched %>%
+      group_by(subject_course) %>%
+      summarize(
+        course_entry_pct = n_distinct(student_id[later_declared]) /
+                           n_distinct(student_id),
+        .groups = "drop"
+      )
+    result <- result %>%
+      left_join(course_rates, by = "subject_course") %>%
+      mutate(entry_pct_vs_course = declaration_pct - course_entry_pct)
+  }
+
   message("[gen-ed-conversion] course-major associations: ",
           nrow(result), " groups")
   attr(result, "association_meta") <- list(

--- a/R/cones/pathway.R
+++ b/R/cones/pathway.R
@@ -660,6 +660,11 @@ plot_curriculum_map <- function(timing_data, opt = list()) {
 #'     \item{`n_took_a`}{Total population students who took course A (denominator).}
 #'     \item{`pct_a_to_b`}{`n_students / n_took_a`: of students who took A,
 #'       what fraction went on to take B?}
+#'     \item{`pct_pop_took_b`}{Baseline: share of all analyzed population
+#'       students who ever took B (any order).}
+#'     \item{`lift`}{`pct_a_to_b / pct_pop_took_b`. Near 1 = B is simply a
+#'       popular course; well above 1 = a genuine sequence signal. Approximate:
+#'       the numerator is order/gap-conditioned, the baseline is not.}
 #'     \item{`median_term_gap`}{Median number of relative terms between taking
 #'       A and taking B.}
 #'   }
@@ -773,6 +778,21 @@ get_course_pairs <- function(students, population, opt = list()) {
   # n_students = distinct students who took A and then took B
   # pct_a_to_b = of everyone who took A, what fraction also took B afterward?
   # median_term_gap = typical number of terms between taking A and taking B
+
+  # Baseline rate for each course B: the share of ALL analyzed population
+  # students who ever took B (any order, uncensored). lift = pct_a_to_b /
+  # pct_pop_took_b — how much more likely A-takers are to go on to B than the
+  # population is to take B at all. Without lift, ubiquitous courses (gen-ed
+  # English, intro math) dominate pct_a_to_b purely by being taken by
+  # everyone: lift ≈ 1 means "B is just popular", well above 1 means a real
+  # sequence signal. Approximate by design: the numerator is order- and
+  # gap-conditioned, the denominator is not.
+  n_pop_students <- n_distinct(enrolled$student_id)
+  b_baseline <- enrolled %>%
+    group_by(subject_course) %>%
+    summarize(n_pop_took_b = n_distinct(student_id), .groups = "drop") %>%
+    mutate(pct_pop_took_b = n_pop_took_b / n_pop_students)
+
   result <- pairs %>%
     group_by(course_a, course_b) %>%
     summarize(
@@ -782,9 +802,17 @@ get_course_pairs <- function(students, population, opt = list()) {
     ) %>%
     inner_join(n_took_a %>% rename(course_a = subject_course), by = "course_a") %>%
     mutate(pct_a_to_b = round(n_students / n_took_a, 3)) %>%
+    left_join(b_baseline %>% rename(course_b = subject_course) %>%
+                select(course_b, pct_pop_took_b),
+              by = "course_b") %>%
+    mutate(
+      lift           = round(pct_a_to_b / pct_pop_took_b, 2),
+      pct_pop_took_b = round(pct_pop_took_b, 3)
+    ) %>%
     filter(n_students >= min_pair_n) %>%
     arrange(desc(n_students)) %>%
-    select(course_a, course_b, n_students, n_took_a, pct_a_to_b, median_term_gap)
+    select(course_a, course_b, n_students, n_took_a, pct_a_to_b,
+           pct_pop_took_b, lift, median_term_gap)
 
   message("[pathway.R] Returning ", nrow(result), " course pairs.")
 

--- a/R/modules/pathways.R
+++ b/R/modules/pathways.R
@@ -426,8 +426,8 @@ pathwaysUI <- function(id, campus_choices, program_choices = character(),
             info_panel("Column guide",
               tags$ul(
                 tags$li(HTML("<strong>Course</strong>: course code.")),
-                tags$li(HTML("<strong>Impact</strong>: positive excess gap multiplied by the number of population students with a DFW. Higher values balance severity and scale.")),
-                tags$li(HTML("<strong>excess_gap</strong>: population stop-out gap minus baseline stop-out gap.")),
+                tags$li(HTML("<strong>Impact</strong>: positive excess gap multiplied by the number of population students with a DFW. Higher values balance severity and scale. Blank when no baseline exists — those rows are shown but not ranked.")),
+                tags$li(HTML("<strong>excess_gap</strong>: population stop-out gap minus baseline stop-out gap. Blank when the course has too few non-population students to form a baseline; the population gap is still shown in <strong>pop_stopout_gap</strong>.")),
                 tags$li(HTML("<strong>pop_stopout_gap</strong>: population DFW stop-out rate minus population pass stop-out rate.")),
                 tags$li(HTML("<strong>baseline_stopout_gap</strong>: the same DFW-vs-pass gap among all non-population students in the course.")),
                 tags$li(HTML("<strong>pop_n_dfw</strong> and <strong>pop_n_pass</strong>: population students in the DFW and passing groups.")),
@@ -559,7 +559,7 @@ pathwaysUI <- function(id, campus_choices, program_choices = character(),
             filter_scope_stripe(div(class = "subtab-scope", uiOutput(ns("cp_meta"))))
           ),
           subtab_intro("Course Pairs",
-            "surfaces common A→B course sequences: of students who took course A, what share later took course B? Useful for spotting de-facto prerequisites and popular follow-ons. Pairs more than the max term gap apart are excluded, and non-ongoing students count only through their last focal term. Course A enrollments are only counted where the data holds the full follow-up window, so recent terms don't deflate the rates."),
+            "surfaces common A→B course sequences: of students who took course A, what share later took course B? Useful for spotting de-facto prerequisites and popular follow-ons. Read % A to B together with Lift — lift near 1 means course B is simply popular with everyone; well above 1 means a genuine sequence signal. Pairs more than the max term gap apart are excluded, non-ongoing students count only through their last focal term, and course A enrollments are only counted where the data holds the full follow-up window, so recent terms don't deflate the rates."),
           reactable::reactableOutput(ns("cp_table"))
         ),
 
@@ -638,6 +638,8 @@ pathwaysUI <- function(id, campus_choices, program_choices = character(),
               tags$li(HTML("<strong>Later major / pre-major</strong> — whether that first later department record was a full major or a pre-major.")),
               tags$li(HTML("<strong>Median terms</strong> — typical number of regular terms between the course and first later department record.")),
               tags$li(HTML("<strong>Entry %</strong> — Later entered ÷ Eligible.")),
+              tags$li(HTML("<strong>Course Avg</strong> — the same course's overall entry rate across all instructors.")),
+              tags$li(HTML("<strong>vs Course</strong> — this instructor's Entry % minus the Course Avg. Compare instructors on this column, not raw Entry %: raw rates differ between courses for reasons that have nothing to do with the instructor (gateway vs. service sections, term mix, campus). Still descriptive — students choose their sections.")),
               tags$li(HTML("<strong>% of Pool</strong> — this group’s Eligible count as a share of all distinct eligible students across all groups. It can sum to more than 100% because one student can take multiple courses.")),
               tags$li(HTML("<strong>Terms</strong> — how many distinct terms this instructor taught this course (indicates sample breadth)."))
             )
@@ -2417,9 +2419,18 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
       }
       result <- result %>%
         mutate(
-          excess_gap   = round(pop_stopout_gap - coalesce(baseline_stopout_gap, 0), 3),
+          # excess_gap is only defined when a baseline exists. Courses with too
+          # few non-population students to form a baseline get NA — NOT zero:
+          # coalescing a missing baseline to 0 would present the course's full
+          # population gap as "excess over baseline" when there is no baseline,
+          # and those population-dominated courses would top the ranking.
+          excess_gap   = dplyr::if_else(
+            is.na(baseline_stopout_gap), NA_real_,
+            round(pop_stopout_gap - baseline_stopout_gap, 3)
+          ),
           # excess_gap × pop DFW count: surfaces courses where the disproportionate
-          # burden is both large and affects many students.
+          # burden is both large and affects many students. NA excess → NA impact,
+          # which arrange() sorts to the bottom (unranked, still visible).
           impact_score = round(pmax(excess_gap, 0) * pop_n_dfw, 1)
         ) %>%
         arrange(desc(impact_score)) %>%
@@ -2805,7 +2816,8 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
     cp_display <- reactive({
       req(cp_data(), nrow(cp_data()) > 0)
       cp_data() %>%
-        select(course_a, course_b, pct_a_to_b, n_students, n_took_a, median_term_gap) %>%
+        select(course_a, course_b, pct_a_to_b, lift, pct_pop_took_b,
+               n_students, n_took_a, median_term_gap) %>%
         arrange(desc(pct_a_to_b))
     })
 
@@ -2831,6 +2843,24 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
           course_b = reactable::colDef(name = "Course B", minWidth = 105),
           pct_a_to_b = reactable::colDef(
             name = "% A to B",
+            align = "right",
+            format = reactable::colFormat(percent = TRUE, digits = 1)
+          ),
+          # Lift anchors % A to B against how common B is overall: near 1 =
+          # B is simply popular; well above 1 = a genuine sequence signal.
+          lift = reactable::colDef(
+            name = "Lift",
+            align = "right",
+            format = reactable::colFormat(digits = 2),
+            style = function(value) {
+              if (is.na(value)) return(list())
+              if (value >= 1.5)      list(fontWeight = "600", color = "#2e7d32")
+              else if (value < 0.9)  list(color = "#9e9e9e")
+              else                   list()
+            }
+          ),
+          pct_pop_took_b = reactable::colDef(
+            name = "% Pop Taking B",
             align = "right",
             format = reactable::colFormat(percent = TRUE, digits = 1)
           ),
@@ -4292,6 +4322,25 @@ pathwaysServer <- function(id, students, programs, degrees = NULL,
           declaration_pct = reactable::colDef(
             name = "Entry %", align = "right", maxWidth = 130,
             format = reactable::colFormat(percent = TRUE, digits = 1)
+          ),
+          course_entry_pct = reactable::colDef(
+            name = "Course Avg", align = "right", maxWidth = 110,
+            format = reactable::colFormat(percent = TRUE, digits = 1)
+          ),
+          # Instructor rate anchored against the SAME course's overall rate —
+          # the honest way to compare instructors (see cone comments).
+          entry_pct_vs_course = reactable::colDef(
+            name = "vs Course", align = "right", maxWidth = 110,
+            cell = function(value) {
+              if (is.na(value)) return("")
+              sprintf("%+.1f%%", value * 100)
+            },
+            style = function(value) {
+              if (is.na(value)) return(list())
+              if (value >= 0.05)       list(fontWeight = "600", color = "#2e7d32")
+              else if (value <= -0.05) list(color = "#A15D4E")
+              else                     list(color = "#9e9e9e")
+            }
           ),
           pct_of_eligible = reactable::colDef(
             name = "% of Pool", align = "right", maxWidth = 100,

--- a/tests/testthat/test-gen-ed-profile.R
+++ b/tests/testthat/test-gen-ed-profile.R
@@ -174,3 +174,41 @@ test_that("get_gen_ed_profile can include chair-facing instructor DFW rows", {
   expect_equal(baker$early_drop_pct, 0)
   expect_equal(baker$n_terms, 1L)
 })
+
+test_that("instructor groups are anchored against their own course's entry rate", {
+  result <- get_course_major_associations(
+    gen_ed_assoc_students,
+    gen_ed_assoc_programs,
+    opt = list(
+      subject_code = "HIST",
+      dept_codes = "HIST",
+      gen_ed_only = TRUE,
+      gen_ed_courses = "HIST 1110",
+      min_n = 1L,
+      group_cols = c("subject_course", "instructor_name")
+    )
+  )
+
+  # Course-wide rate: 4 distinct eligible students, 3 entered = 0.75.
+  # (Group n_eligible sums to 5 because one student took both instructors.)
+  expect_true(all(result$course_entry_pct == 0.75))
+
+  adams <- result %>% dplyr::filter(instructor_name == "Adams, Erin")
+  baker <- result %>% dplyr::filter(instructor_name == "Baker, Lee")
+  expect_equal(adams$entry_pct_vs_course, 0.25)          # 1.00 - 0.75
+  expect_equal(round(baker$entry_pct_vs_course, 3), -0.083)  # 0.667 - 0.75
+})
+
+test_that("course-only grouping does not add instructor anchoring columns", {
+  result <- get_course_major_associations(
+    gen_ed_assoc_students,
+    gen_ed_assoc_programs,
+    opt = list(
+      subject_code = "HIST", dept_codes = "HIST",
+      gen_ed_only = TRUE, gen_ed_courses = "HIST 1110",
+      min_n = 1L, group_cols = "subject_course"
+    )
+  )
+  expect_false("course_entry_pct" %in% names(result))
+  expect_false("entry_pct_vs_course" %in% names(result))
+})

--- a/tests/testthat/test-pathway.R
+++ b/tests/testthat/test-pathway.R
@@ -736,3 +736,28 @@ test_that("get_course_pairs without censor_term preserves uncensored behavior", 
   expect_true("BIOL 2310" %in% result$course_a)
   expect_null(attr(result, "pair_meta")$a_boundary)
 })
+
+
+# =============================================================================
+# get_course_pairs() lift — pct_a_to_b anchored against B's overall popularity
+# =============================================================================
+# Population of 5: BIOL 2310 taken by 5/5 (baseline 1.0), ENGL 1110 by 4/5
+# (0.8), CHEM 1215 by 4/5 (0.8).
+
+test_that("get_course_pairs lift compares the A-to-B rate with B's overall take rate", {
+  result <- get_course_pairs(
+    make_pathway_students(), make_pathway_population(),
+    opt = list(min_n = 1, min_pair_n = 1, max_term_gap = 2)
+  )
+
+  chem_biol <- result %>% filter(course_a == "CHEM 1215", course_b == "BIOL 2310")
+  expect_equal(chem_biol$pct_pop_took_b, 1)
+  expect_equal(chem_biol$lift, 1)          # 1.0 / 1.0 — B is universal, no signal
+
+  chem_engl <- result %>% filter(course_a == "CHEM 1215", course_b == "ENGL 1110")
+  expect_equal(chem_engl$pct_pop_took_b, 0.8)
+  expect_equal(chem_engl$lift, 0.94)       # 0.75 / 0.8 — below-baseline follow-on
+
+  biol_engl <- result %>% filter(course_a == "BIOL 2310", course_b == "ENGL 1110")
+  expect_equal(biol_engl$lift, 1)          # 0.8 / 0.8
+})


### PR DESCRIPTION
Implements the three remaining "cheap fixes" from the Pathways audit. **Stacked on #52** (base branch is `pathways-observation-window`; GitHub retargets to `main` automatically when #52 merges — merge #52 first).

## 1. Roadblocks: `excess_gap` no longer invents a baseline

`coalesce(baseline_stopout_gap, 0)` presented a course's full population gap as "excess over baseline" exactly when there was **no baseline** — and those population-dominated courses topped the Impact ranking. Now: no baseline → `excess_gap` and Impact are blank; rows stay visible (the population gap is still shown) but sort unranked to the bottom. Column guide says so.

## 2. Course Pairs: lift column

`pct_a_to_b` alone ranks popularity as much as sequencing. New `lift = pct_a_to_b ÷ pct_pop_took_b` (share of all analyzed students who ever took B): **near 1 = B is just popular; well above 1 = genuine sequence signal.** Styled in the table (≥1.5 bold green, <0.9 muted), explained in the intro, documented as approximate (numerator is order/gap-conditioned, baseline is not).

## 3. Course to Major: instructor rows anchored to their own course

Raw Entry % differs between courses for reasons unrelated to instructors (gateway vs. service sections, term mix, campus). The cone now emits `course_entry_pct` and `entry_pct_vs_course` when grouping by course + instructor; the table adds **Course Avg** and a signed, colored **vs Course** column, and the column guide directs comparisons there. Uses the same within-course-anchor pattern as `course-outcomes.R`'s instructor DFW.

## Tests

Pinned: lift 1.0 (universal follow-on) and 0.94 (below-baseline) on the pathway fixture; course rate 0.75 with Adams +0.25 / Baker −0.083 on the gen-ed association fixture; anchoring columns absent for course-only grouping. Full suite `FAIL 0 | SKIP 38 | PASS 1778`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)