### PR TITLE
Project audit: add ROADMAP.md and bring the reference docs back in line with the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 Open-source Shiny analytics platform for higher ed curriculum, enrollment, and student experience at UNM. Primary data sources are Banner/MyReports extracts. Primary audience is IR staff and deans using the Shiny app, with a secondary audience of analysts using the cones directly in RStudio.
 
-**For AI agents doing broad codebase work** — debugging, adding features, understanding architecture, navigating modules, or working across multiple files. This is the comprehensive reference: full architecture, data model, coding standards, module patterns, CSS gotchas, test infrastructure, and refactoring status.
+**For AI agents doing broad codebase work** — debugging, adding features, understanding architecture, navigating modules, or working across multiple files. This is the comprehensive reference: full architecture, data model, coding standards, module patterns, CSS gotchas, and test infrastructure.
 
-**Instructions for agents:** Trust the layer rules (trunk/branches/cones/reports) and the coding standards sections — they reflect hard-won decisions, not suggestions. Check the refactoring status before touching any file listed there. When in doubt about data structure, the authoritative source is `R/data-parsers/transform-to-cedar.R`.
+**Instructions for agents:** Trust the layer rules (trunk/branches/cones/reports) and the coding standards sections — they reflect hard-won decisions, not suggestions. The cleanup backlog and refactoring status live in `NEXT-STEPS.md` — check it before touching any file listed there. When in doubt about data structure, the authoritative source is `R/data-parsers/transform-to-cedar.R`.
 
 ---
 
@@ -152,6 +152,9 @@ get_my_analysis <- function(students, opt = list()) {
 | `headcount.R` | `get_headcount(programs, opt)` | Student enrollment counts by program |
 | `credit-hours.R` | `get_credit_hours(students, opt)` | Credit hour production |
 | `degrees.R` | `count_degrees(degrees, opt)` | Degree completion counts |
+| `course-flows.R` | `get_next_course_pairs(students, opt, source_courses)`, `get_previous_course_pairs(students, opt, target_courses)` | Campus-scoped source→destination course pairs across adjacent terms. Course sequencing always joins and groups by campus so students at different campuses are never treated as one flow |
+| | `get_course_destinations()`, `get_course_feeders()`, `get_concurrent_courses()`, `get_course_flow_neighbors()` | Summaries of what students take after / before / alongside a course; `get_course_flow_neighbors()` returns the combined named list |
+| `pathways.R` | `pathways_level_filter()`, `pathways_observation_boundary()`, `apply_pathways_population_window()`, `resolve_pathways_focal_programs/dept_codes/subjects()` | Pure result-shaping helpers for the Pathways module — calculation-affecting rules kept testable without loading Shiny |
 
 ### Cones — Single-Question Analyses (`R/cones/`)
 
@@ -190,6 +193,15 @@ get_my_analysis <- function(students, opt = list()) {
 | `course-demographics.R` | `get_course_demographics(students, opt)` | — | Major/classification breakdown per course |
 | `sfr.R` | `get_permanent_faculty_fte(faculty, opt)` | — | Faculty FTE by dept |
 | `gened-fulfillment.R` | `get_gened_fulfillment(...)` | — | Gen ed area fulfillment by major |
+| `cancellations.R` | `get_cancellations(sections, opt)` | — | Cancelled sections (section status "C") plus summary tables for Explore > Cancellations; related non-active statuses counted separately for context |
+| `gen-ed-conversion.R` | `get_gen_ed_conversion(students, programs, opt)` | — | Sankey flows from a student's program at the time of a gen-ed course to their last recorded program (graduated / stopped-out labeled); flows below `opt$min_n` collapsed into "Other" |
+| | `get_course_major_associations(students, programs, opt)` | — | Course → eventual-major association table |
+| `health-whatif.R` | `get_health_course_rates(programs, students, program_names, ...)` | — | Weighted course-taking rates per (program, course, term_type) for health programs: steady-state (`rate`) and new-entrant (`entry_rate`) weightings. Powers the Admin > Healthcare tab |
+| | `project_health_increase(rates, sizes, ...)`, `get_section_size_lookup(sections, ...)` | — | What-if projection: seat and section demand implied by program enrollment increases |
+| | `get_premajor_pipeline()`, `get_health_course_trends()`, `get_course_pressure()`, `get_actual_course_demand()`, `get_enrollment_matrix()` | — | Supporting pipeline / trend / pressure / demand views for the Healthcare tab |
+| `forecast/` (subdir) | `forecast(students, courses, opt)` (`forecast.R`) | — | Course enrollment forecasting orchestrated across methods; the only cone subdirectory — methods split one per file |
+| | `major_forecast()` (`method-major.R`), `conduit_forecast()` (`method-conduit.R`) | — | Forecast methods: declared-majors-based and feeder-course ("conduit") |
+| | `calc_forecast_accuracy()`, `create_forecast_report()` (`forecast-stats.R`) | — | Forecast accuracy statistics and Rmd report |
 
 ### Grade Data In Cones
 
@@ -222,7 +234,8 @@ Reports call multiple branches/cones and render Rmd output. They follow differen
 
 | File | Main function(s) | Purpose |
 |------|-----------------|---------|
-| `course-report.R` | `get_course_report_data(students, sections, opt)` | Assembles enrl + gradebook + lookout + forecast → HTML/ASPX |
+| `course-report.R` | `create_course_report_data(data_objects, opt)`, `create_course_report(data_objects, opt)` | Assembles enrl + gradebook + course flows + forecast for the Course Dynamics tab and rendered course report |
+| `gen-ed.R` | `get_gen_ed_profile(students, sections, programs, degrees, opt)` | Gen Ed profile (scope filtering, outcome rates, grade distribution, major mix) for Explore > Gen Ed and the Dept Profile Gen Ed panel |
 | `dept-dashboard.R` | `create_dept_dashboard_data(...)` | Dashboard metrics and plots for one dept (assembles headcount, enrl, credit-hour trends) |
 | | `get_subject_current_stats(sections, subject, term)` | Lightweight current-term snapshot: returns `list(n_sections, total_enrl)` for a subject, crosslist-deduplicated. No full dashboard pipeline. Reusable in dashboard cards, comparison views, future API endpoints. |
 | `dept-report.R` | `get_dept_report_data(...)` | Assembles headcount + degrees + credit-hours + gened → HTML/ASPX |
@@ -264,7 +277,7 @@ get_course_timing(cedar_students, population, opt = list())
 
 **`population$first_unit_term` is scoped to the focal programs.** It is the first term each student appeared in a focal program record (e.g., Geography). Do NOT re-derive entry terms by querying `programs %>% filter(student_id %in% focal_ids) %>% group_by(student_id) %>% summarize(entry_term = min(term))` — that picks up ALL of a student's program history across every major they ever held, not just the focal program. Use `population$first_unit_term` directly instead.
 
-**Adding a new population type:** Add a `build_X_population(programs, opt)` helper in `population.R` and wire into `build_population()`. The Shiny wiring lives in `R/modules/pathways.R`, which contains `cohortBuilderUI` / `cohortBuilderServer` — the UI still uses the word "cohort" in its internal names even though the underlying branch was renamed to `population`.
+**Adding a new population type:** Add a `build_X_population(programs, opt)` helper in `population.R` and wire into `build_population()`. The Shiny wiring lives in `R/modules/pathways.R` (`populationSelectorUI` / `populationSelectorServer`).
 
 **Observational comparisons:** When you need treatment/control groups (e.g., took course X vs. didn't), use `build_comparison()` and `compute_balance()` from `branches/comparison.R`. See `course-impact.R` for the reference pattern.
 
@@ -382,11 +395,28 @@ Introduced with the Pathways tab. Use for all new feature tabs. Do not refactor 
 
 ```
 R/modules/pathways.R
-  cohortBuilderUI(id, program_choices, campus_choices)
-  cohortBuilderServer(id, programs)    → returns reactive cohort tibble
-  pathwaysUI(id, program_choices, campus_choices)
-  pathwaysServer(id, students, programs, degrees = NULL)
+  populationSelectorUI(id, campus_choices, program_choices = character(), ...)
+  populationSelectorServer(id, programs, degrees = NULL, students = NULL, ...)
+                                        → returns reactive population tibble
+  pathwaysUI(id, campus_choices, program_choices = character(), ...)
+  pathwaysServer(id, students, programs, degrees = NULL, ...)
 ```
+
+### Module inventory
+
+| File | UI / server pairs | Mounted at |
+|------|-------------------|------------|
+| `pathways.R` | `pathwaysUI/Server`, `populationSelectorUI/Server` | Pathways |
+| `headcount.R` | `headcountUI/Server` | Explore > Headcount |
+| `seatfinder.R` | `seatfinderUI/Server` | Explore > Open Seats |
+| `cancellations.R` | `cancellationsUI/Server` | Explore > Cancellations |
+| `waitlist.R` | `waitlistUI/Server` | Explore > Waitlists |
+| `gen-ed.R` | `genEdExploreUI/Server`, `deptProfileGenEdUI/Server` | Explore > Gen Ed; Dept Profile Gen Ed panel |
+| `regstats.R` | `regstatsUI/Server` | Regstats |
+| `health-whatif.R` | `healthWhatIfUI/Server` | Admin > Healthcare |
+| `retention.R` | `retentionUI/Server` | **Hidden** — UI commented out in ui.R pending cross-course comparison (`retentionServer` is still wired in server.R); course-level retention lives in Course Dynamics |
+| `admin.R` | `changelogUI/Server`, `cacheUI/Server` | Admin (changelog + cache management) |
+| `ui-helpers.R` | shared UI primitives, not a module: `filter_bar`, `filter_scope_stripe`, `info_panel`, `empty_state`, `section_block`, `dept_selector_bar`, … | used across modules and ui.R |
 
 **Layout pattern:**
 ```r
@@ -543,46 +573,12 @@ Common opt keys across cones:
 
 ## Refactoring Status
 
-### Phase 1: Quick Cleanup
-- [x] Rename `rollcall.R` → `course-demographics.R`; `rollcall()` → `get_course_demographics()` (all call sites updated)
-- [x] Delete `R/cones/course-report-orig.R` (380 LOC, no references)
-- [x] Delete `Rmd/dept-report-orig.Rmd` (no references)
-- [ ] Remove commented-out code from Rmd files
-- [x] Add `STATUS_REGISTERED <- c("RE", "RS", "RR")` and `STATUS_WAITLIST` to `status_codes.R`
-- [x] Add `GRADES_DFW` and `GRADES_PASS` to `R/lists/grades.R`
-- [x] Update `stopout.R` to use shared constants
-- [x] Add `dedup_enrollment()` and `classify_grades()` to `trunk/utils.R`
-- [x] Restructure layers: trunk/ (infrastructure), branches/ (domain computations), cones/ (single-question), reports/ (orchestrators)
-- [x] Remove `is_lab` flag — defined but never consumed by any analysis. L-suffix courses remain in all counts.
-- [x] Extract `get_course_section_counts()` from server.R inline block → `enrl.R`
-- [x] Extract `filter_downstream_by_dept()` from two duplicated server.R blocks → `regstats.R`
-- [x] Extract `get_subject_current_stats()` from server.R inline block → `dept-dashboard.R`
-- [x] Replace all inline `c("RE", "RS", "RR")` with `STATUS_REGISTERED` in pathway.R, bottleneck.R, and test files
-- [x] Remove dead `get_course_list()` from utils.R (zero callers)
-- [x] Remove studio testing comments from enrl.R and seatfinder.R
-- [x] Remove always-on DEBUG messages from headcount.R
-- [x] Add `validate_population()` to utils.R; replace duplicate inline checks in pathway.R, stopout.R, bottleneck.R
-- [x] Add arithmetic comments to `add_next_term_col()` explaining the YYYYSS offset math
-- [x] Add rationale comments to `min_n` defaults in stopout.R and pathway.R
-- [x] Add year-band rationale comment to credit thresholds in pathway.R
-- [ ] Standardize `dept` vs `dept_code` in opt objects (large sweep, low priority)
-
-### Phase 2: Shiny Modules
-- [x] **Pathways tab** — complete, in `R/modules/pathways.R`. Use as reference.
-- [x] Headcount module — complete, in `R/modules/headcount.R`, wired in server.R
-- [ ] Seatfinder module
-- [ ] Others only when the tab needs significant new work anyway
-
-### Phase 3: Break Up Long Cone Functions
-- [ ] `enrl.R` (936 LOC): extract `count_by_status()` from repeated filter/summarize blocks
-- [ ] `regstats.R` (933 LOC): separate cache management from analysis
-- [ ] `credit-hours.R` (876 LOC): split `get_credit_hours_for_dept_report` into sub-functions
-- [ ] `lookout.R` (757 LOC): decompose anomaly detection from trend analysis
-
-### Phase 4: Externalize Domain Data
-- [ ] Move department/program mappings in `mappings.R` to YAML/CSV
-- [ ] Make college code configurable (currently hardcoded `"AS"` in `credit-hours.R`)
-- [ ] Document all remaining hardcoded domain values
+**The cleanup backlog and its status live in `NEXT-STEPS.md` Part 2** — one
+status list, kept current there. (The phase checklists that used to live here
+were duplicated, drifted stale, and were removed 2026-07-12; completed-phase
+knowledge that still matters — e.g. the `is_lab` removal — is documented in
+the relevant sections above.) `ROADMAP.md` holds the strategic priorities
+across code, docs, UX, and operations.
 
 ---
 

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -204,6 +204,19 @@ with the ones used by live tabs:
   (657 lines) — verify they still pass the trunk test ("would work for a
   different analytics project"); if CEDAR-specific report knowledge has crept
   in, split it out.
+- [ ] **E4 (S):** Remove commented-out code from `Rmd/` files (carried over
+  from the retired AGENTS.md Phase 1 checklist).
+
+### F. Externalize domain data (carried over from the retired AGENTS.md Phase 4)
+
+Prerequisite work for any second-institution deployment; also the fix path for
+mapping-gap issues (#22 MPP, #12 PADM, #33 SHS). See ROADMAP.md Theme 4.
+
+- [ ] **F1 (M):** Move department/program mappings in `R/lists/mappings.R`
+  (and `subj_dept_map.R`) to YAML/CSV data files.
+- [ ] **F2 (S):** Make the college code configurable (currently hardcoded
+  `"AS"` in `credit-hours.R`).
+- [ ] **F3 (M):** Document all remaining hardcoded domain values.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,366 @@
+# CEDAR Roadmap — Project Audit and Priorities
+
+Audit date: 2026-07-12. This document is the strategic layer above the two
+existing working documents:
+
+- **`AGENTS.md`** — the architecture *reference*: what the layers are, what the
+  tables contain, how to write code here.
+- **`NEXT-STEPS.md`** — the tactical *work queue*: a prioritized code-cleanup
+  backlog from the 2026-07-09 architecture audit, plus standing agent rules.
+- **`ROADMAP.md`** (this file) — *direction and priorities* across the whole
+  project: code, documentation, UX, testing, operations, and the collective
+  vision. It says where effort should go and why; item-level code tasks stay
+  in NEXT-STEPS.md and are referenced by their IDs (A1, B2, D3…).
+
+When an item here is picked up, track it the usual way: one PR per item,
+check it off, and update whichever of the three documents it invalidates.
+
+---
+
+## 1. Where the project stands
+
+**The vision is well-articulated and the architecture broadly delivers on it.**
+The docs site (`docs/index.md`, `why-cedar.md`, `questions.md`) makes a coherent
+case: transparent, reproducible, unit-level curriculum analytics whose
+methodology *is* the code, organized so analytical work accumulates instead of
+resetting. The six-layer architecture (lists → trunk → branches → cones →
+reports → modules), the fixtures-based test suite (~43 test files), the
+institutionalized DFW policy, the cache-key correctness rule, the CI-gated
+Docker deploy, and the changelog/spotlight system are all real, working
+expressions of that vision.
+
+**The codebase is mid-refactor and the refactor is going well.** The 2026-07-09
+audit (NEXT-STEPS.md Part 2) fixed all architecture violations (A1–A4) within
+days. What remains is the long-tail decomposition work (B-items), plotly
+standardization (C1), and test-coverage gaps (D-items).
+
+**The biggest gaps are not in the code — they are in documentation drift and
+in the user-facing trust story.** The reference docs have fallen behind the
+code in specific, enumerable ways (§4), and the open GitHub issues show users
+hitting exactly the problem CEDAR exists to solve — numbers that don't
+reconcile between views — *inside CEDAR itself* (§3).
+
+Scale snapshot (for calibrating the backlog):
+
+| Surface | Size |
+|---|---|
+| `server.R` (inline legacy tabs) | 5,207 lines |
+| `R/modules/pathways.R` | 4,361 lines (was 4,271 at the 07-09 audit — it is still growing) |
+| Total R code | ~42,600 lines |
+| Cones / branches / reports / modules | 18 / 11 / 5 / 11 files |
+| Test files | 43, fixtures-based |
+| Open GitHub issues | 11 (oldest from 2025-04) |
+
+---
+
+## 2. Strategic direction — five themes
+
+These are the through-lines that should drive prioritization. Individual tasks
+in §3–§7 each serve one of these.
+
+### Theme 1: Internal reconciliation is the product promise — treat it as a feature
+
+CEDAR's pitch is "when numbers don't reconcile, the code makes the difference
+explainable." The open issues show the pitch inverted: users can't reconcile
+CEDAR with CEDAR. Issue #31 (Enrollment *Trends* vs *Plots* disagree for the
+same course), #32 (Dept Dashboard says a course is "down" at 51 vs an average
+of 47), and the AGENTS.md note that "Trends intentionally ignores exact
+term-code filters" all point the same way: **different tabs make different
+filtering/scoping choices, and those choices are invisible in the UI.**
+
+Direction: every table/plot that applies a non-obvious scope (crosslist
+dedup on or off, summer included or not, term filters ignored, census vs
+current enrollment) should say so on-screen — a scope stripe or caption, not
+a docs page. A user should never need the repo to explain why two CEDAR tabs
+differ. This is the highest-leverage UX investment available and it is mostly
+captions and small UI affordances, not new analytics.
+
+### Theme 2: Finish the decomposition before adding major features
+
+`server.R` (5,207 lines, six inline tabs) and `pathways.R` (4,361-line module
+with leaked business logic) are where bugs will hide and where every future
+change gets slower. The B-items in NEXT-STEPS.md are the plan; the roadmap
+point is *sequencing*: the pathways module grew ~90 lines since the audit
+three days ago, which means new Pathways work is still landing in the module
+instead of in cones. Hold the line: no new `group_by`/`summarize` in modules,
+and schedule B2 (pathways push-down) soon so the debt stops compounding.
+
+### Theme 3: Close the documentation loop or the reference docs will stop being trusted
+
+AGENTS.md is explicitly "the authoritative reference," and agents and human
+contributors act on it. It currently omits four cones, two branches, one
+report, and nine of eleven modules (§4). The public developer docs still point
+at the old `fredgibbs/cedar` repo and describe a three-layer architecture that
+became six layers. Stale authoritative docs are worse than no docs — they
+cause confident wrong behavior. The fix is bounded (a few hours of updates)
+plus a ritual: **every PR that adds/renames a cone, branch, or module updates
+AGENTS.md in the same diff** (this rule already exists in NEXT-STEPS §1.5 —
+it needs enforcing, because the undocumented files all postdate it).
+
+### Theme 4: Make the "collective" claim installable
+
+The docs promise adaptability across institutions, but UNM-specific knowledge
+is hardcoded: college code `"AS"` in `credit-hours.R`, department/program
+mappings in `R/lists/mappings.R` and `subj_dept_map.R`, campus and term
+conventions. NEXT-STEPS.md section F (externalize domain data to YAML/CSV) is the
+right move and should be treated as a real milestone — it is also the answer
+to a whole class of user issues (#22 MPP, #12 PADM, #33 SHS) that are really
+program→department mapping gaps that currently require code changes to fix.
+A reviewable, data-file-driven mapping layer would let mapping corrections be
+config PRs, ideally editable/verifiable via the existing Admin → Mappings tab.
+
+### Theme 5: Decide the surface portfolio deliberately
+
+CEDAR currently ships four surfaces: the Shiny app (primary), the CLI
+(`cedar.R` + `command-handler.R`), a Plumber API (`plumber.R`), and rendered
+Rmd reports. Each has maintenance cost (command-handler.R is one of the
+remaining `get_grades()` consumers; plumber.R duplicates data loading). Worth
+an explicit decision: which surfaces are supported products, which are
+experiments, and which should be documented as unsupported. The docs currently
+advertise all of them equally.
+
+---
+
+## 3. User-facing issues (GitHub triage)
+
+All 11 open issues, grouped by root cause. These are the users' actual
+priorities and several are quick wins.
+
+**Reconciliation / trust (Theme 1):**
+- **#31** — Enrollment *Trends* sub-tab vs *Plots* sub-tab show different
+  pictures for the same course (CJ 1130). Likely the documented
+  different-filter-scope behavior; needs an on-screen scope explanation or a
+  genuine bug fix if scopes should match.
+- **#32** — Dept Dashboard "down from average" logic confusing/wrong for
+  ANTH 2190C (51 shown as *down* from an average of 47). Investigate the
+  historical-average comparison and its labeling.
+
+**Program/department mapping gaps (Theme 4):**
+- **#33** — Speech & Hearing: Master's/doctoral students missing; Explore tab
+  fails for the department. Likely mapping and/or grad-program coverage.
+- **#22** — Add MPP to department reports.
+- **#12** — Confirm PADM reports include health-admin students (mapping
+  boundary question — the answer should be visible in the Admin Mappings tab).
+- **#18** — MSST Dept Report errors outright. A department whose report
+  crashes is also a missing-test case: reproduce, fix, and pin with a fixture
+  edge case if the data shape is unusual.
+
+**Feature requests (small, high goodwill):**
+- **#35** — Downloadable spreadsheet of SCH from Dept Trends → Credit Hours.
+  A general pattern is better: audit which tables lack CSV download buttons
+  and add a standard download affordance to the table helper.
+- **#36** — Add race/ethnicity/gender to the Demographics views. The columns
+  exist in `cedar_programs` (`ipeds_race`, `gender`); this is display wiring
+  plus small-cell suppression policy (decide a minimum-n rule before shipping).
+- **#14** — DFW by instructor name in the web tool. `course-outcomes.R`
+  already computes `instructor_dfw`; this is a display/permissions decision
+  (named-instructor data is politically sensitive — decide policy, then wire).
+- **#7** — Faculty counts from CEDAR. `get_permanent_faculty_fte()` exists in
+  `sfr.R`; expose or document.
+
+**Plot polish:**
+- **#36 (second half)** — Gen Ed path diagram appears truncated.
+- **#34** — Date axis formatting on Headcount → Undergrad majors (headcount.R
+  is also on the ggplot→plotly conversion list, C1 — fix together).
+
+Also: several issues have sat unanswered since 2025. Even a triage pass that
+labels each (bug / mapping / feature / question) and posts a one-line status
+would strengthen the collaborative-project story the docs lead with.
+
+---
+
+## 4. Documentation debt (specific, verified)
+
+### 4.1 AGENTS.md (the authoritative reference) is missing recent work
+
+**Done 2026-07-12** — cone/branch/report tables updated, module inventory
+added, stale `cohortBuilder`/`lookout.R`/`get_course_report_data` references
+fixed, and the duplicated Refactoring Status section replaced with a pointer
+to NEXT-STEPS.md (open items carried over as NEXT-STEPS E4 and F1–F3).
+Original findings kept below for the record:
+
+- **Cones absent from the cone table:** `health-whatif.R` (1,425 lines — also
+  a whole "Healthcare" UI tab), `cancellations.R`, `gen-ed-conversion.R`, and
+  the `forecast/` subdirectory (4 files: `forecast.R`, `forecast-stats.R`,
+  `method-conduit.R`, `method-major.R` — the only cone subdirectory; its
+  pattern should be documented or flattened).
+- **Branches absent from the branch table:** `course-flows.R`,
+  `pathways.R` (branch).
+- **Reports absent from the report table:** `gen-ed.R`.
+- **No module inventory exists.** Eleven modules ship
+  (`admin`, `cancellations`, `gen-ed`, `headcount`, `health-whatif`,
+  `pathways`, `regstats`, `retention`, `seatfinder`, `ui-helpers`, `waitlist`);
+  AGENTS.md names only pathways and headcount. Add a module table mirroring
+  the cone table.
+- **Stale checkboxes/counts:** Phase 2 lists "Seatfinder module" as not done —
+  `R/modules/seatfinder.R` exists (429 lines). Phase 3 line counts are stale
+  (`enrl.R` "936" → actual 1,328; etc. — NEXT-STEPS B4 has current numbers).
+  The Phase lists in AGENTS.md and Part 2 of NEXT-STEPS.md now overlap;
+  consider deleting the AGENTS.md "Refactoring Status" section entirely in
+  favor of NEXT-STEPS.md so there is exactly one status list.
+
+### 4.2 Public developer docs (docs/developers/) predate the current architecture
+
+**Mostly done 2026-07-12** — repo URLs fixed (`fredgibbs` → `cedar-collective`
+in index, contributing, installation), `index.md` rewritten for the six-layer
+architecture with a current cone list, generator output path and front matter
+fixed, `functions.md` regenerated (132 functions, was 77; needs a UTF-8
+locale: see the usage note in `scripts/generate-function-docs.R`). Still open:
+a fresh-install verification pass over `installation.md` / `cli-usage.md`.
+Original findings kept below for the record:
+
+- `index.md` and `contributing.md` link to `github.com/fredgibbs/cedar`; the
+  project lives at `cedar-collective/cedar` (which `inspecting-cedar.md`
+  correctly uses). Issue links, clone commands, and fork instructions all
+  point at the wrong repo.
+- `index.md` describes a **three-layer** architecture (trunk/branches/cones)
+  and a project tree without `R/lists/`, `R/reports/`, `R/modules/`, or
+  `R/trunk/`. It should describe the six-layer model, or better, link to a
+  single canonical architecture page generated from/aligned with AGENTS.md.
+- `functions.md` (2,159 lines) says "auto-generated" with a timestamp of
+  **2026-02-04** — five months stale. Worse, the generator
+  (`scripts/generate-function-docs.R`) writes to `docs/reference/functions.md`,
+  a path that doesn't exist; someone moved the output to
+  `docs/developers/functions.md` without updating the script. Fix the script's
+  `OUTPUT_DIR`, regenerate, and add regeneration to a release ritual (or a CI
+  step) so it can't drift silently again.
+- Worth a pass over `installation.md` / `cli-usage.md` to confirm the
+  `setup.R` / `cedar.R -f shiny` instructions still match reality (the local
+  renv situation in §6 suggests the install path deserves a fresh test).
+
+### 4.3 User docs (docs/users/) are good but have coverage gaps
+
+The per-tab guides are recent and match the current tab names. Missing pages:
+
+- **Healthcare tab** (`health-whatif`) — a 3,100-line feature with zero user
+  documentation.
+- **Retention** (Explore → Retention, `R/modules/retention.R`) — no page.
+- **Admin / Data & Usage** — no page explaining the Mappings review surface,
+  which is the tool users need for the mapping-gap issues in §3.
+- `questions.md` refers to a "**Department Profile** tab" and issue traffic
+  uses it too, while the UI and user guide say "Dept Trends" / "Dept
+  Dashboard." Pick the canonical names, sweep `questions.md`, changelog
+  entries, and UI labels for agreement.
+
+### 4.4 Root-level docs
+
+- `README.md` is thin: no vision statement, no screenshot, no link to the
+  user/developer split, just Docker data-mount notes. For a project whose
+  strategy depends on adoption and contribution, the README is the front
+  door — a half-page rewrite pointing to the docs site would pay for itself.
+- `docs/grade-data-contract-audit.md` is a completed migration audit; mark it
+  as historical (or move it to a `docs/decisions/` folder — see §7).
+
+---
+
+## 5. Testing gaps
+
+The fixtures infrastructure is strong; coverage is uneven. Confirmed missing
+test files (extends NEXT-STEPS D-items):
+
+| Untested surface | Risk |
+|---|---|
+| `branches/comparison.R` + `cones/course-impact.R` (D2) | **Highest** — observational treatment/control machinery; silent-wrongness produces confidently wrong causal claims |
+| `cones/health-whatif.R` + its module | High — 3,100 lines, live tab, zero tests |
+| `branches/credit-hours.R` (D3) | High — SCH numbers go into program review; only indirectly covered |
+| `cones/bottleneck.R`, `course-neighbors.R`, `course-retention.R`, `gened-fulfillment.R`, `branches/degrees.R` (D4) | Medium |
+| `cones/forecast/` (4 files) | Medium — has `test-forecast.R`, verify it covers all four method files |
+| `reports/course-report.R` render path | Medium — dept-report has tests, course-report does not |
+
+Also from §3: every user-reported crash (#18 MSST, #33 SHS) should land with a
+fixture edge case reproducing the data shape that broke, per the existing
+edge-case policy in AGENTS.md.
+
+E2E: the `tests/e2e/` harness exists and works, but only `nav.test.mjs`
+asserts anything. The two reconciliation issues (#31, #32) are exactly the
+kind of cross-tab behavior only e2e can pin — one "same course, same filters,
+two tabs agree" test would guard the product promise directly.
+
+---
+
+## 6. Operations and repo hygiene
+
+- **Local renv is recurrently broken** (per project memory: broken again
+  2026-07-09 after a 2026-06-17 repair). Standing workaround is
+  `Rscript --vanilla`. Decide: either fix renv for real (rebuild the local
+  library and document the recovery), or officially demote renv to
+  "Docker-only" and update AGENTS.md test instructions to `--vanilla`
+  everywhere so agents stop rediscovering this.
+- **Tracked files inside an ignored directory:** `/output/` is gitignored but
+  `output/csv/enrollments.csv`, `output/dept-reports/html/HIST.html`, and
+  `output/parse-data-summary.log` are committed (pre-ignore legacy). `git rm
+  --cached` them so generated artifacts stop shipping in the repo.
+- **Branch hygiene:** ~15 merged local branches and their remote counterparts
+  linger (`fix-*`, `regstats-part-of-term`, `serve-app-at-root`, several
+  `copilot/*` and `claude/*`). Prune merged branches; decide whether the
+  unmerged ones (`feature/cedar-data-model`, `feature/dept-dashboard`,
+  `pathways-concept-docs`, `chore/cleanup-and-whatsnew`, `delete-ai-reference`)
+  are live, mergeable, or deletable — unmerged branches are invisible WIP.
+- **Versioning:** the changelog uses versions (v.10.3.0) but no version string
+  exists in code/config. Cheap fix: single source of truth in `config/` that
+  the changelog and an About footer both read.
+- **Plumber API** loads its own copy of all CEDAR data at startup, separate
+  from the Shiny app. If it's a supported surface (Theme 5), it needs a
+  deploy story and tests; if not, mark it experimental in-file and in docs.
+
+---
+
+## 7. Suggested sequencing
+
+### Now (next 2–4 weeks) — trust, truth, and quick wins
+
+1. **Issue triage pass** — label all 11 issues, answer the stale ones (§3).
+2. **Reconciliation fixes**: investigate #31 and #32; ship scope
+   stripes/captions for any intentionally different scoping (Theme 1). Add
+   one e2e reconciliation test.
+3. **Mapping bugs**: #18 (MSST crash) and #33 (SHS) — fix with fixture
+   edge cases; #22/#12 via mapping data updates.
+4. ~~**AGENTS.md truth pass** (§4.1)~~ — done 2026-07-12, along with most of
+   the developer-docs refresh (§4.2).
+5. **Quick-win features**: CSV download affordance (#35), demographics
+   columns with a small-cell suppression rule (#36).
+
+### Next (1–2 months) — decomposition and docs
+
+6. **B2: pathways module push-down** — stop the compounding debt (Theme 2).
+7. **B1 extractions** — continue one tab per PR (Data & Usage first, per
+   NEXT-STEPS order), with C1 plotly conversions riding along (#34 fixes the
+   headcount axis while converting `headcount.R`).
+8. ~~**Developer docs refresh** (§4.2)~~ — mostly done 2026-07-12; remaining:
+   fresh-install verification of `installation.md` / `cli-usage.md`.
+9. **User doc gaps** (§4.3): Healthcare, Retention, Admin pages; naming sweep.
+10. **D2 tests** (comparison/course-impact) before any new observational
+    features ship.
+11. **README rewrite** (§4.4).
+
+### Later (this year) — the platform bets
+
+12. **Domain-data externalization** (NEXT-STEPS F, Theme 4): mappings to data files, college
+    code configurable, Admin tab as the mapping-review workflow. This is the
+    prerequisite for any second-institution deployment.
+13. **Surface portfolio decision** (Theme 5): support/experimental status for
+    CLI, Plumber, Rmd reports; align docs and `get_grades()` migration plan
+    (the legacy bundle's remaining consumers are course-report, dept-report,
+    and the CLI — the decision here determines whether that migration ever
+    finishes).
+14. **Remaining B3/B4 decompositions and D3/D4 tests** as standing
+    between-feature work.
+15. **Decision records**: start a lightweight `docs/decisions/` folder (the
+    DFW policy, cache-key rule, and grade-contract audit are already de facto
+    ADRs scattered across AGENTS.md and docs/) so policy decisions accumulate
+    the same way the vision says analyses should.
+
+---
+
+## 8. Recurring rituals (keep the audit from being needed again)
+
+- Every PR adding/renaming a cone/branch/module updates AGENTS.md tables in
+  the same diff (existing rule — enforce it in review).
+- Regenerate `functions.md` on release (or in CI) once the generator path is
+  fixed.
+- Monthly: issue triage; prune merged branches.
+- Per release: changelog entry (already habitual), version bump once a
+  version source of truth exists.
+- Quarterly: re-run the line-count snapshot in §1 and check it against the
+  complexity budget in NEXT-STEPS §1.4 — growth in `server.R` or any module
+  is the early-warning signal.

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -12,7 +12,7 @@ Thanks for your interest in contributing to CEDAR! We welcome contributions of a
 
 ### Report Bugs
 
-Found something broken? [Open an issue](https://github.com/fredgibbs/cedar/issues) with:
+Found something broken? [Open an issue](https://github.com/cedar-collective/cedar/issues) with:
 
 - What you were trying to do
 - What you expected to happen

--- a/docs/developers/functions.md
+++ b/docs/developers/functions.md
@@ -8,65 +8,706 @@ parent: Developer Guide
 
 This reference is auto-generated from roxygen2 comments in the source code.
 
-*Generated: 2026-02-04 10:58:03.752177*
+*Generated: 2026-07-12 15:07:40.419617*
+
+---
+
+## bottleneck
+
+### `get_bottlenecks()`
+
+*Source: bottleneck.R*
+
+**Get Enrollment Demand Bottlenecks for a Cohort**
+
+Get Enrollment Demand Bottlenecks for a Cohort  For each course, counts cohort students who are waitlisted but hold no registered seat — the clearest signal of unmet demand. Results are returned per-course, sorted by waitlist count.  If the cohort contains multiple labels (from `build_population()` with `include_pre_majors = "split"`), a `$by_label` table is also returned showing results broken out by cohort label.
+
+**Parameters:**
+
+- `cohort` - Data frame. Output of `build_population()`. Must have columns `student_id` and `population_label`.
+- `students` - Data frame. The `cedar_students` table.
+- `opt` - List of options: \describe{ \item{`term`}{Integer or character vector of term codes to restrict to. Optional; defaults to all terms.} \item{`campus`}{Character vector of campus codes. Optional.} }
+
+**Returns:** Named list: \describe{ \item{`waitlist`}{Data frame of enrollment bottlenecks, sorted descending by `n_waitlisted`. Columns: `subject_course`, `n_waitlisted`.} \item{`population_size`}{Named integer vector: number of unique student IDs per cohort label.} \item{`by_label`}{Data frame breaking down waitlist counts by `population_label`. Only present when the cohort has more than one distinct label.} }
+
+**Example:**
+```r
+\dontrun{
+cedar_programs <- qs_read("data/cedar_programs.qs")
+cedar_students <- qs_read("data/cedar_students.qs")
+
+cohort <- build_population(cedar_programs, opt = list(type = "health"))
+result <- get_bottlenecks(cohort, cedar_students, opt = list())
+result$waitlist
+result$population_size
+}
+
+```
+
+---
+
+### `compute_waitlist_pressure()`
+
+*Source: bottleneck.R*
+
+**Compute Waitlist Pressure for a Student Cohort**
+
+Compute Waitlist Pressure for a Student Cohort  Counts cohort students who are waitlisted for a course and hold no registered seat in that course — i.e., students who couldn't get in. Students who are both waitlisted and registered (hedging across sections) are excluded from the count.
+
+**Parameters:**
+
+- `students` - Data frame. The `cedar_students` table, optionally pre-filtered by term/campus.
+- `cohort_ids` - Character vector of student IDs to include.
+
+**Returns:** Data frame sorted descending by `n_waitlisted`: \describe{ \item{`subject_course`}{Course identifier, e.g., `"BIOL 2310"`.} \item{`n_waitlisted`}{Unique cohort students waitlisted and not registered for this course.} }
+
+---
+
+## cancellations
+
+### `get_cancellations()`
+
+*Source: cancellations.R*
+
+**Analyze Cancelled Course Sections**
+
+Analyze Cancelled Course Sections  Returns cancelled section rows and summary tables for the Explore > Cancellations page. Cancellation is defined narrowly as section status "C"; related non-active statuses are counted separately for page context.
+
+**Parameters:**
+
+- `sections` - CEDAR sections table.
+- `opt` - Filter options compatible with filter_DESRs().
+
+**Returns:** Named list with cancelled sections, summary tables, and status notes.
+
+---
+
+## comparison
+
+### `build_comparison()`
+
+*Source: comparison.R*
+
+**Build a labeled treatment/control tibble with covariates and balance stats**
+
+Build a labeled treatment/control tibble with covariates and balance stats  Joins covariates from cedar_programs at each student's reference term and optionally cedar_applicants. Returns labeled groups and a balance table with standardized mean differences so the caller can assess comparability.  By default, covariates are pulled at the student's entry term (first term in the system). Callers can pass \code{covariate_terms} to use a specific term per student instead — e.g., the term they took course X — which gives a more meaningful snapshot of GPA and credits at the point of comparison.
+
+**Parameters:**
+
+- `treatment_ids` - Character vector of student IDs in the treatment group.
+- `pool_ids` - Character vector of eligible control student IDs. Must already exclude treatment_ids and any ineligible students.
+- `programs` - cedar_programs data frame.
+- `applicants` - cedar_applicants data frame, or NULL to skip admissions covariates.
+- `students` - cedar_students data frame, used to determine each student's entry term (first term with any enrollment). If NULL, entry term is derived from programs instead.
+- `covariate_terms` - Optional named integer vector or two-column tibble (student_id, covariate_term) giving the term at which to pull program covariates for each student. Overrides the entry-term default for any student present in this argument; students not listed fall back to entry term.
+
+**Returns:** Named list: \describe{ \item{groups}{Tibble: student_id, group ("treatment"/"control"), entry_term, and all available covariates.} \item{balance}{Named list from compute_balance(): smd_table and categorical.} \item{n_treatment}{Integer. Students in treatment group.} \item{n_control}{Integer. Students in control group.} }
+
+---
+
+### `compute_balance()`
+
+*Source: comparison.R*
+
+**Compute covariate balance between treatment and control groups**
+
+Compute covariate balance between treatment and control groups  For binary and continuous covariates, computes group means/proportions and standardized mean differences (SMDs). |SMD| < 0.1 indicates good balance; |SMD| > 0.25 is flagged as potentially problematic.  SMD formulas: Binary:     (p_t - p_c) / sqrt(p_bar * (1 - p_bar)) Continuous: (mu_t - mu_c) / sqrt((var_t + var_c) / 2)  Categorical covariates (ipeds_race, time_status, etc.) are returned as frequency distributions rather than SMDs — proportions don't reduce to a single meaningful scalar.
+
+**Parameters:**
+
+- `groups` - Tibble from build_comparison() with a "group" column.
+
+**Returns:** Named list: \describe{ \item{smd_table}{Tibble sorted by |SMD| descending: covariate, type, n_treatment, n_control, value_treatment, value_control, unit, smd, flagged.} \item{categorical}{Named list of frequency tibbles for categorical covariates.} }
+
+---
+
+## course-demographics
+
+### `abbreviate_classification()`
+
+*Source: course-demographics.R*
+
+**Abbreviate Student Classification Labels**
+
+Abbreviate Student Classification Labels  Converts verbose MyReports classification labels to shorter display labels to prevent layout issues in pie charts and legends.
+
+**Parameters:**
+
+- `classification` - Character vector of student classification values
+
+**Returns:** Character vector with abbreviated labels
+
+**Example:**
+```r
+abbreviate_classification("Freshman, 1st Yr, 1st Sem")  # Returns "Freshman"
+abbreviate_classification("Junior, 3rd Yr.")  # Returns "Junior"
+```
+
+---
+
+### `get_course_major_mix()`
+
+*Source: course-demographics.R*
+
+**Get Major Mix for a Course Set**
+
+Get Major Mix for a Course Set  Summarizes the major/program mix for students enrolled in a selected set of courses. Counts are enrollment rows, not unique students, so a student taking two selected courses contributes two seats to the mix. The enrollment-row major code is used as the baseline because it is attached to the course term; same-term primary program records are used when available for cleaner names and pre-major labels.
+
+**Parameters:**
+
+- `students` - Data frame of student enrollments from cedar_students.
+- `programs` - Data frame of program records from cedar_programs.
+- `opt` - Options list. Supports course/term/campus/college filters accepted by filter_class_list(), plus min_n and top_n for display grouping.
+
+**Returns:** Tibble with major_label, n_enrollments, n_students, pct_enrollments.
+
+---
+
+### `create_demographics_color_palette()`
+
+*Source: course-demographics.R*
+
+**Create Consistent Color Palette for Demographics Plots**
+
+Create Consistent Color Palette for Demographics Plots  Generates a consistent color mapping for categories across multiple plots to ensure the same majors/classifications have the same colors in fall, spring, and summer plots.
+
+**Parameters:**
+
+- `demographics_data` - A dataframe from \code{summarize_student_demographics()}.
+- `fill_column` - The column name to use for color mapping (e.g., "student_classification" or "major")
+- `top_n` - Number of top categories to include in color palette (default: 10)
+
+**Returns:** A named vector of colors where names are category values
+
+**Example:**
+```r
+color_palette <- create_demographics_color_palette(demographics_data, "major", top_n = 8)
+```
+
+---
+
+### `plot_demographics_summary()`
+
+*Source: course-demographics.R*
+
+**Plot Demographics Summary (Donut Charts)**
+
+Plot Demographics Summary (Donut Charts)  Creates interactive donut charts showing the average distribution of student classifications or majors for a course, grouped by term type (fall, spring, summer).  This function does NOT perform calculations. It expects pre-calculated values from \code{\link{summarize_student_demographics}}: \itemize{ \item \code{mean} - Average student count for each category across terms of same term_type \item \code{term_type_pct} - Percentage based on average total enrollment for term_type }
+
+**Parameters:**
+
+- `demographics_data` - Data frame from \code{summarize_student_demographics()}. Must contain columns: fill_column, term_type, mean, term_type_pct, campus, college, subject_course
+- `fill_column` - Column name to group by (e.g., "student_classification" or "major")
+- `color_palette` - Named vector of colors from \code{create_demographics_color_palette()}
+- `filter_column` - Optional list with \code{column} and \code{values} for filtering
+
+**Returns:** Named list of plotly donut charts: fall, spring, summer, by_term
+
+---
+
+### `get_course_demographics()`
+
+*Source: course-demographics.R*
+
+**Get Course Demographics**
+
+Get Course Demographics  Analyzes the demographic composition (majors, classifications, etc.) of students in a course or set of courses over time. Returns counts, means across terms, and percentages of course enrollment — answering "who is in this course?"
+
+**Parameters:**
+
+- `students` - Data frame of student enrollments from cedar_students table.
+- `opt` - Options list for filtering and grouping: \itemize{ \item \code{group_cols} - Character vector of columns to group by. If NULL, uses defaults: campus, college, term, term_type, student_classification, major, subject_course, course_title, level \item \code{reg_status_code} - Registration status codes to include (default: STATUS_REGISTERED) \item \code{course} - Course identifier(s) to filter by \item \code{term} - Term code(s) to filter by \item Other filtering options supported by \code{filter_class_list()} }
+
+**Returns:** Data frame with student demographic breakdown including counts, means, and percentages. See \code{\link{summarize_student_demographics}} for column details.
+
+**Example:**
+```r
+\dontrun{
+# Major composition of a course over time
+opt <- list(
+  course     = "BIOL 2305",
+  group_cols = c("campus", "term", "term_type", "major", "subject_course")
+)
+major_breakdown <- get_course_demographics(cedar_students, opt)
+
+# Classification breakdown across all MATH courses
+opt <- list(
+  subject    = "MATH",
+  group_cols = c("campus", "term", "student_classification", "subject_course")
+)
+class_breakdown <- get_course_demographics(cedar_students, opt)
+}
+
+```
+
+---
+
+### `plot_time_series()`
+
+*Source: course-demographics.R*
+
+**Plot Classification Time Series**
+
+Plot Classification Time Series  Creates line plots showing the actual term-level percentage of students in each classification or major across terms over time.
+
+**Parameters:**
+
+- `demographics_data` - A dataframe from \code{summarize_student_demographics()}.
+- `fill_column` - Column to group by (default: "student_classification")
+- `value_column` - Column to use for y-axis values (default: "term_pct")
+- `top_n` - Number of top categories to display (default: 5)
+
+**Returns:** A plotly object showing time series lines.
+
+---
+
+### `plot_demographics_with_consistent_colors()`
+
+*Source: course-demographics.R*
+
+**Plot Demographics with Consistent Colors Across Terms**
+
+Plot Demographics with Consistent Colors Across Terms  Wrapper that creates demographics donut charts with a consistent color mapping across all term types (fall, spring, summer).
+
+**Parameters:**
+
+- `demographics_data` - A dataframe from \code{summarize_student_demographics()}.
+- `fill_column` - The column name to use for fill aesthetic.
+- `top_n` - Number of top categories to include (default: 7)
+- `filter_column` - Optional list with column name and values to filter (e.g., list(column = "campus", values = c("ABQ")))
+
+**Returns:** A list of plotly charts with consistent colors across term types.
+
+**Example:**
+```r
+consistent_plots <- plot_demographics_with_consistent_colors(demographics_data, "major", top_n = 8)
+```
+
+---
+
+## course-impact
+
+### `get_course_retention()`
+
+*Source: course-impact.R*
+
+**Course Retention Comparison**
+
+Course Retention Comparison  Compares multi-term persistence between students who took a target course (treatment) and comparable students who didn't (control). Primary use case is college-success or intervention courses like FYEX 1110.  The eligible control pool is scoped to students entering in the same terms as treatment students and matching opt$eligible_populations. Interactive covariate filters (opt$filters) can narrow both groups further so users can test whether the retention gap holds within specific subgroups.
+
+**Parameters:**
+
+- `students` - cedar_students data frame.
+- `programs` - cedar_programs data frame.
+- `applicants` - cedar_applicants data frame, or NULL.
+- `opt` - Named list of options: \describe{ \item{course}{Character vector. Subject_course value(s) defining treatment (e.g., "FYEX 1110"). Required.} \item{eligible_populations}{Character vector of student_population values that define who could have taken the course. Default: first-time freshman populations.} \item{campus}{Character vector. Restrict to these campus codes. Optional.} \item{n_terms}{Integer. Semesters of retention to track (default 3).} \item{min_n}{Integer. Minimum students per group (default 15).} \item{filters}{Named list of covariate equality filters applied after group assignment, e.g., list(first_gen = TRUE). Optional.} }
+
+**Returns:** Named list: \describe{ \item{course}{Treatment course(s).} \item{retention}{Tibble: group, terms_out, n, n_enrolled, rate, ci_low, ci_high.} \item{group_profile}{Compact covariate summary for each group.} \item{balance}{From compute_balance(): smd_table + categorical distributions.} \item{n_treatment, n_control}{Group sizes after any filters.} \item{groups}{Full labeled tibble — pass back to Shiny for dynamic filtering.} }
+
+---
+
+### `get_course_sequence_effect()`
+
+*Source: course-impact.R*
+
+**Course Sequence Effect**
+
+Course Sequence Effect  Compares grades in course Y between students who passed course X before taking Y (treatment) and students who took Y without prior X (control). Surfaces whether completing X meaningfully prepares students for Y.
+
+**Parameters:**
+
+- `students` - cedar_students data frame.
+- `programs` - cedar_programs data frame.
+- `applicants` - cedar_applicants data frame, or NULL.
+- `opt` - Named list: \describe{ \item{course_x}{Character. The preparatory course. Required.} \item{course_y}{Character. The outcome course. Required.} \item{campus}{Character vector. Optional campus filter.} \item{min_n}{Integer. Minimum students per group (default 15).} \item{filters}{Named list of covariate equality filters. Optional.} }
+
+**Returns:** Named list: \describe{ \item{course_x, course_y}{Course identifiers.} \item{outcomes}{Tibble: group, outcome (pass/dfw), n, pct.} \item{group_profile}{Compact covariate summary per group.} \item{balance}{From compute_balance().} \item{n_treatment, n_control}{Group sizes.} }
+
+---
+
+### `get_instructor_effect()`
+
+*Source: course-impact.R*
+
+**Downstream Success by Instructor**
+
+Downstream Success by Instructor  Among students who took course X and later took course Y, compares grade outcomes in Y between students taught by different instructors in X. Surfaces descriptive differences in downstream outcomes by upstream instructor.  The balance table reveals whether instructor sections self-selected different kinds of students — the most common confounder in multi-section courses.
+
+**Parameters:**
+
+- `students` - cedar_students data frame.
+- `programs` - cedar_programs data frame.
+- `applicants` - cedar_applicants data frame, or NULL.
+- `opt` - Named list: \describe{ \item{course_x}{Character. The upstream course. Required.} \item{course_y}{Character. The downstream outcome course. Required.} \item{campus}{Character vector. Optional campus filter.} \item{min_n}{Integer. Minimum students per instructor who later took Y (default 15). Instructors below this threshold are excluded.} }
+
+**Returns:** Named list: \describe{ \item{course_x, course_y}{Course identifiers.} \item{outcomes}{Tibble: instructor_name, outcome, n, total, pct.} \item{instructor_counts}{Tibble: instructor_name, n (students who took Y).} \item{balance}{Balance between the two most-common instructors' student pools.} \item{n_treatment, n_control}{Sizes for the reference instructor comparison.} }
+
+---
+
+## course-outcomes
+
+### `get_course_outcomes()`
+
+*Source: course-outcomes.R*
+
+**Analyze outcomes for one or more courses**
+
+Analyze outcomes for one or more courses  Runs all three outcome analyses — persistence, DFW trend, and instructor comparison — and returns them as a named list.  DFW trend and instructor comparison delegate to get_course_outcome_rates() so the DFW formula and component fields match the rest of the app.  Persistence filtering and deduplication are handled internally.
+
+**Parameters:**
+
+- `students` - cedar_students data frame.
+- `cedar_faculty` - cedar_faculty data frame, or NULL to skip DFW analyses.
+- `opt` - Options list: \itemize{ \item \code{course}  — character vector of subject_course values (required) \item \code{term}    — integer vector; restrict to these terms (optional) \item \code{campus}  — character vector; restrict by campus (optional) \item \code{min_n}   — integer; minimum graded students per group (default 5) }
+
+**Returns:** Named list: \describe{ \item{persistence}{Tibble from \code{next_term_persistence()}} \item{dfw_trend}{Tibble: campus, college, subject_course, term, dfw_pct (from gradebook)} \item{instructor_dfw}{Tibble: campus, college, subject_course, instructor_last_name, dfw_pct, course_avg_dfw, dfw_diff (from gradebook)} \item{courses}{Character vector of courses analyzed} }
+
+---
+
+### `next_term_persistence()`
+
+*Source: course-outcomes.R*
+
+**Next-term persistence by grade outcome**
+
+Next-term persistence by grade outcome  For each grade outcome (pass / dfw / drop), reports how many students returned to any course the following term. Gives a course-level view of whether bad outcomes actually drive students away.  Uses the full \code{all_students} table (not pre-filtered) as the enrollment source when checking whether a student returned — so next-term returns outside the filtered course set are detected correctly.  Early drops get their own "drop" outcome here, separate from academic DFW, because the persistence question is different for each group.
+
+**Parameters:**
+
+- `filtered` - Deduplicated cedar_students rows for the target course(s).
+- `all_students` - Full cedar_students table.
+- `opt` - Options list; uses \code{opt$min_n} (default 5).
+
+**Returns:** Tibble: subject_course, outcome, n_students, n_returned, pct_returned; sorted by subject_course, outcome.
 
 ---
 
 ## credit-hours
 
-### `get_enrolled_cr()`
-
-*Source: credit-hours.R*
-
-**Get Enrolled Credit Hours**
-
-Get Enrolled Credit Hours  Analyzes credit hour enrollments for students. Returns summary statistics on student enrollment credits.
-
-**Parameters:**
-
-- `filtered_students` - Data frame of student enrollments (CEDAR format) Must contain columns: student_id, term, total_credits, term_type
-- `courses` - List of course codes to filter (optional)
-- `opt` - Options list (optional)
-
-**Returns:** Wide-format data frame with enrollment counts by term and credit load
-
-**Details:**
-
-CEDAR-only function - requires CEDAR column names: - student_id (not `Student ID`) - term (not `Academic Period Code`) - total_credits (not `Total Credits`) - term_type (must be present)
-
-**Example:**
-```r
-\dontrun{
-enrollment_stats <- get_enrolled_cr(students, courses, opt)
-}
-```
-
----
-
 ### `get_credit_hours()`
 
 *Source: credit-hours.R*
 
-**Get Credit Hours Summary**
+**Summarize credit hours by term, campus, college, department, subject, and level**
 
-Get Credit Hours Summary  Creates a summary of earned credit hours from class lists (CEDAR format). Filters for passing grades and summarizes by term, campus, college, department, level, and subject.
+Summarize credit hours by term, campus, college, department, subject, and level  This is the foundational summary used by all department-level SCH plots. It counts only credit hours earned through passing grades — we don't count withdrawals, failures, or incompletes because those don't represent completed academic work from the department's perspective.  The result includes both individual level rows (lower/upper/grad) AND a "total" row per group that sums across all levels — so downstream callers can choose either view without re-aggregating.
 
 **Parameters:**
 
-- `students` - Data frame of student enrollments (CEDAR class_lists format) Must contain columns: final_grade, term, campus, college, department, level, subject_code, credits
+- `students` - cedar_students data frame
 
-**Returns:** Data frame with credit hours summarized by term, campus, college, department, subject, and level Includes a "total" level that aggregates across all course levels
+**Returns:** Long-format data frame with columns: term, campus, college, department, subject_code, level, total_hours. Level values: "lower", "upper", "grad", "total".
 
-**Details:**
+---
 
-CEDAR-only function - requires CEDAR column names: - final_grade (not `Final Grade`) - term (not `Academic Period Code`) - campus (not `Course Campus Code`) - college (not `Course College Code`) - department (not DEPT) - subject_code (not `Subject Code`) - credits (not `Course Credits`)  Only counts credit hours for passing grades (defined in passing_grades global).
+### `build_major_level_data()`
 
-**Example:**
-```r
-\dontrun{
-credit_hours <- get_credit_hours(class_lists)
-}
-```
+*Source: credit-hours.R*
+
+**Filter and normalize student data for credit-hours-by-major analysis**
+
+Filter and normalize student data for credit-hours-by-major analysis  Before we analyze who is taking courses in a department, we need to narrow the data to the right time window and remove students who didn't pass.  Also fixes a Banner data inconsistency: the College of Education appears under two different strings depending on the export vintage. We normalize to one display name so grouping works correctly.
+
+**Parameters:**
+
+- `students` - cedar_students data frame
+- `term_start` - Integer term code for the beginning of the analysis window
+- `term_end` - Integer term code for the end of the analysis window
+
+**Returns:** Filtered data frame, ready for major-level analysis
+
+---
+
+### `build_major_summary()`
+
+*Source: credit-hours.R*
+
+**Summarize SCH by major and split into home vs. outside**
+
+Summarize SCH by major and split into home vs. outside  For a given set of course enrollment rows (already filtered to a level like "lower" or "upper"), this function totals the credit hours per major and then divides them into two groups: - "Home" majors: students whose declared major belongs to this department - "Outside" majors: students from other departments who are taking these courses  This is the foundation of the pie charts that show a department's service function to the rest of the university.
+
+**Parameters:**
+
+- `level_data` - Filtered student enrollment rows for one course level Required cols: major, major_name, credits
+- `major_codes` - Character vector of major codes that belong to this department (e.g., c("BIOL", "FBIO", "CHBI") for Biology)
+
+**Returns:** Named list with slots: major_summary — all majors with total hours home          — only the department's own majors outside       — all other majors home_hours, outside_hours, total_hours — scalar totals
+
+---
+
+### `build_outside_pie_data()`
+
+*Source: credit-hours.R*
+
+**Group outside majors by display name and decide which get their own slice**
+
+Group outside majors by display name and decide which get their own slice  The raw outside-major data can have dozens of programs. If we gave every small program its own slice, the pie chart would become unreadable. But a hard "top N" cutoff can hide important groups — for example, Nursing students might be the #10 largest group but still represent a meaningful story.  Instead we use a percentage threshold: any program that accounts for at least 3% of total outside SCH gets a named slice. The rest roll into "Other". We cap the named groups at 12 to keep the legend legible.  Each Banner program code gets its own slice. Display names are carried in major_name for use in tables only — plots label by major_code so that code variants (NURS, FNRS, FNAP) are visible separately rather than being silently merged or split by name drift.  The color map built here is shared with the time-series bar chart, so each program code gets the same color in both views.
+
+**Parameters:**
+
+- `outside_summary` - The "outside" slot from build_major_summary() — a data frame with major_code, major_name, and total_hours columns
+- `pct_threshold` - Fraction of outside SCH required for a named slice (default 0.03 = 3%)
+- `max_named` - Hard cap on the number of named slices (default 12)
+
+**Returns:** Named list: outside_for_pie — complete ranking of all outside programs by code + name; used as the full export table named_outside   — only programs that clear the threshold (capped at max_named) top_outside     — named_outside plus an "Other" row for everything else color_map       — named character vector mapping each major_code to a color outside_total   — scalar: total outside SCH
+
+---
+
+### `build_outside_time_data()`
+
+*Source: credit-hours.R*
+
+**Build the term-by-term data for the outside-major bar chart**
+
+Build the term-by-term data for the outside-major bar chart  The pie charts show averages across the whole analysis window. The time- series bar chart shows the same grouping (same named programs, same "Other" bucket) but laid out term by term so you can see trends over time.  The named programs here must match exactly what build_outside_pie_data() selected, so the two charts tell a consistent story: a program named in the pie also appears as its own bar in the time series.
+
+**Parameters:**
+
+- `level_data` - Filtered student enrollment rows for one course level Required cols: major, major_name, credits, term
+- `major_codes` - Home department major codes — excluded from outside count
+- `named_outside_codes` - The major_code values from build_outside_pie_data() $named_outside — these are the program codes that get their own bar color
+
+**Returns:** Data frame: term (as a factor), major_group (chr), total_hours (dbl)
+
+---
+
+### `build_credit_hours_wide_table()`
+
+*Source: credit-hours.R*
+
+**Build the wide-format SCH summary table (major × term)**
+
+Build the wide-format SCH summary table (major × term)  This is the export table that appears in the report alongside the charts. It shows each major as a row and each term as a column, so a reader can scan across a row to see how a program's SCH has changed over time.  A "Total" row at the bottom sums every column, and missing values (a major that didn't appear in a particular term) are shown as 0. Rows are sorted by the most recent term so the most active programs appear first.
+
+**Parameters:**
+
+- `filtered_students` - Filtered student rows (all levels combined)
+
+**Returns:** Wide data frame: student_college, major, then one column per term
+
+---
+
+### `compute_major_sch_trends()`
+
+*Source: credit-hours.R*
+
+**Compute SCH growth and decline trends for outside majors**
+
+Compute SCH growth and decline trends for outside majors  This function asks: "Which outside programs are sending more or fewer students to this department compared to the recent past?"  We measure trends over three windows: 1-year, 2-year, and 4-year. Each window compares the average SCH over the most recent N terms against the same-length window immediately before that.  Summer terms are excluded from all windows because summer enrollment behaves very differently from the regular academic year — including summer would distort the averages and make year-over-year comparisons misleading.  We rank by absolute change (e.g., +200 SCH) rather than percentage change (e.g., +20%) to avoid a tiny program with explosive percentage growth appearing more important than a large program with modest but consequential absolute growth.  Window requirements (needs enough history in the data): 1yr: needs ≥ 4 fall/spring terms in the range 2yr: needs ≥ 6 fall/spring terms 4yr: needs ≥ 10 fall/spring terms
+
+**Parameters:**
+
+- `level_data` - Filtered student enrollment rows for one course level
+- `major_codes` - Home department codes — only outside majors are analyzed
+- `top_n` - How many top growing and declining programs to return (default 5)
+
+**Returns:** list(growing, declining) — each a data frame with top_n rows, or NULL if there isn't enough history to compute any window
+
+---
+
+### `build_indexed_growth_data()`
+
+*Source: credit-hours.R*
+
+**Build the department-vs-college indexed growth comparison data**
+
+Build the department-vs-college indexed growth comparison data  To understand whether a department's SCH growth is impressive or just keeping pace, we compare it against its whole college. We index both series to 100 at the first term — not because the starting value was 100, but so the two lines start at the same point and divergence becomes visible.  A department line above the college line means it's growing faster than average for the college. Below means it's falling behind relative to peers. The chart answers: "Is this department outpacing its college, or lagging?"
+
+**Parameters:**
+
+- `credit_hours_data` - Output of get_credit_hours(), already filtered to the desired term range
+- `dept_code` - Department code (e.g., "BIOL")
+- `dept_college` - College code this department belongs to (e.g., "AS")
+
+**Returns:** Long-format data frame: term (factor), series (chr), indexed_value (dbl) series values: "<dept_code> Department" and "<dept_college> College"
+
+---
+
+### `build_college_credit_hours()`
+
+*Source: credit-hours.R*
+
+**Build college-wide credit hour data and department comparison frames**
+
+Build college-wide credit hour data and department comparison frames  Produces three related summaries used by the college-level plots:  1. All departments in the college, summed by term — for the stacked bar showing how the whole college's SCH is distributed  2. Just this department's rows — used as the comparison line  3. A year-over-year delta comparison — shows how many percentage points faster or slower the department grew compared to the college as a whole (positive = outpacing the college that year; negative = lagging)
+
+**Parameters:**
+
+- `credit_hours_data` - Output of get_credit_hours(), filtered to term range
+- `dept_college` - College code for this department
+- `dept_code` - Department code
+
+**Returns:** Named list: college_credit_hours, dept_credit_hours, diff_fr_college_hours
+
+---
+
+### `build_dept_subject_data()`
+
+*Source: credit-hours.R*
+
+**Build subject-level credit hour data for the department's own plots**
+
+Build subject-level credit hour data for the department's own plots  This prepares three differently-shaped views of the same data — all filtered to just this department's courses on main campuses — for three different charts that visualize the same information at different levels of detail.
+
+**Parameters:**
+
+- `credit_hours_data` - Output of get_credit_hours(), filtered to term range
+- `dept_code` - Department code
+
+**Returns:** Named list with three data frames: by_subj_level — one row per (term, subject, level), level is NOT "total"; used for the faceted chart showing each subject broken down by lower/upper/grad by_subj_total — one row per (term, subject), level IS "total"; used for the stacked chart and the data export table by_period     — one row per (term, level) with an added period_hours column (the sum across all subjects for that level and term); used for the by-level stacked bar
+
+---
+
+### `plot_outside_majors_pie()`
+
+*Source: credit-hours.R*
+
+**Donut chart: which outside programs are taking courses here?**
+
+Donut chart: which outside programs are taking courses here?  Shows the breakdown of outside-major SCH across all terms in the range. Each named slice is a program that sent enough students to clear the threshold; everything else is rolled into "Other".
+
+**Parameters:**
+
+- `top_outside` - top_outside slot from build_outside_pie_data()
+- `color_map` - color_map slot from build_outside_pie_data()
+- `level_label` - Display label for the title (e.g., "Lower Division")
+
+**Returns:** plotly donut chart, or NULL if there are no outside majors
+
+---
+
+### `plot_home_outside_pie()`
+
+*Source: credit-hours.R*
+
+**Pie chart: what share of SCH goes to the department's own students?**
+
+Pie chart: what share of SCH goes to the department's own students?  A simple two-slice chart: "Department Majors" vs. "Outside Majors". A service department (like English composition or core science) will show a large outside slice; a specialized program will show a large home slice.
+
+**Parameters:**
+
+- `home_hours,outside_hours,total_hours` - Scalar SCH totals from build_major_summary()
+- `level_label` - Display label for the title
+
+**Returns:** plotly pie chart, or NULL if total_hours is 0
+
+---
+
+### `plot_outside_time_series()`
+
+*Source: credit-hours.R*
+
+**Stacked bar: outside major credit hours by term**
+
+Stacked bar: outside major credit hours by term  Shows the same programs as the pie chart but over time, so you can see whether outside-major enrollment is growing, shrinking, or shifting among programs. Uses the same colors as the pie chart for direct visual comparison.
+
+**Parameters:**
+
+- `time_data` - Output of build_outside_time_data()
+- `color_map` - color_map slot from build_outside_pie_data()
+- `level_label` - Display label for the title
+
+**Returns:** plotly stacked bar chart, or NULL if time_data is empty
+
+---
+
+### `plot_indexed_growth()`
+
+*Source: credit-hours.R*
+
+**Line chart: department vs. college indexed SCH growth**
+
+Line chart: department vs. college indexed SCH growth  Both lines start at 100 (the first term in the analysis window) so their trajectories can be directly compared regardless of their actual sizes. If the department line is above the college line, the department is growing faster than its college peers.
+
+**Parameters:**
+
+- `indexed_data` - Output of build_indexed_growth_data()
+- `dept_code` - Used to identify the department series by name
+
+**Returns:** ggplot line + point chart
+
+---
+
+### `plot_college_credit_hours()`
+
+*Source: credit-hours.R*
+
+**Stacked bar: all departments in the college, showing each department's share**
+
+Stacked bar: all departments in the college, showing each department's share  Provides context for the department's SCH within its college — is this a large department, a medium one, or a small one relative to peers?
+
+**Parameters:**
+
+- `college_credit_hours` - college_credit_hours slot from build_college_credit_hours()
+
+**Returns:** ggplotly interactive bar chart
+
+---
+
+### `plot_college_comp()`
+
+*Source: credit-hours.R*
+
+**Bar chart: how much faster or slower is the department growing vs. its college?**
+
+Bar chart: how much faster or slower is the department growing vs. its college?  Bars above zero mean the department grew faster than the college average that year; bars below zero mean it grew slower. A consistently positive department is gaining share; a consistently negative one is losing share.
+
+**Parameters:**
+
+- `diff_fr_college_hours` - diff_fr_college_hours slot from build_college_credit_hours()
+
+**Returns:** ggplot bar chart
+
+---
+
+### `plot_chd_by_subj_faceted()`
+
+*Source: credit-hours.R*
+
+**Faceted bar chart: credit hours by subject code and course level**
+
+Faceted bar chart: credit hours by subject code and course level  Creates one panel per subject code (e.g., BIOL, BIOC, BIOM), with bars stacked by level (lower/upper/grad) so you can see both the volume and the mix for each subject area.
+
+**Parameters:**
+
+- `by_subj_level` - by_subj_level slot from build_dept_subject_data()
+- `palette` - RColorBrewer palette name for the level fill colors
+
+**Returns:** ggplot with one facet panel per subject code
+
+---
+
+### `plot_chd_by_subj_stacked()`
+
+*Source: credit-hours.R*
+
+**Stacked bar: total credit hours by subject code across all levels**
+
+Stacked bar: total credit hours by subject code across all levels  A simpler view than the faceted chart — all subjects stacked in one bar per term, useful for seeing which subject area dominates and how the mix shifts over time.
+
+**Parameters:**
+
+- `by_subj_total` - by_subj_total slot from build_dept_subject_data()
+
+**Returns:** ggplot stacked bar chart
+
+---
+
+### `plot_chd_by_level()`
+
+*Source: credit-hours.R*
+
+**Stacked bar: total credit hours by course level (lower/upper/grad)**
+
+Stacked bar: total credit hours by course level (lower/upper/grad)  Shows the balance between undergraduate and graduate instruction over time. A shift in this chart might signal a change in the department's graduate program size or a major curriculum redesign.
+
+**Parameters:**
+
+- `by_period` - by_period slot from build_dept_subject_data()
+- `subj_codes` - Subject codes shown in the chart title for reference
+- `palette` - RColorBrewer palette name
+
+**Returns:** ggplot stacked bar chart
 
 ---
 
@@ -74,55 +715,37 @@ credit_hours <- get_credit_hours(class_lists)
 
 *Source: credit-hours.R*
 
-**Credit Hours By Major**
+**Credit Hours by Major**
 
-Credit Hours By Major  Analyzes earned credit hours broken down by student major. Shows which majors are earning credit hours in department courses.
+Credit Hours by Major  The main function for the "who is taking our courses" analysis. Runs the full pipeline three times — once for lower division, once for upper division, and once for all undergrad combined — then assembles all plots and tables.
 
 **Parameters:**
 
-- `students` - Data frame of student enrollments (CEDAR class_lists format) Must contain columns: department, term, final_grade, credits, major, student_college
-- `d_params` - Department parameters list containing: - dept_code: Department code to filter - term_start: Starting term (inclusive) - term_end: Ending term (inclusive) - prog_names: Vector of program names for major comparison
+- `students` - cedar_students data frame (pre-filtered to this department)
+- `dept_code` - Department code (e.g., "BIOL")
+- `term_start,term_end` - Integer term codes for the analysis window (inclusive)
 
-**Returns:** d_params list with added elements: - tables$credit_hours_data_w: Wide-format credit hours by major and term - plots$sch_outside_pct_plot: Pie chart of non-major credit hour distribution - plots$sch_dept_pct_plot: Pie chart comparing major vs non-major credit hours
-
-**Details:**
-
-CEDAR-only function - requires CEDAR column names: - department (not DEPT) - term (not `Academic Period Code`) - final_grade (not `Final Grade`) - credits (not `Course Credits`) - major (should be in CEDAR format) - student_college (not `Student College`)
-
-**Example:**
-```r
-\dontrun{
-d_params <- credit_hours_by_major(class_lists, d_params)
-}
-```
+**Returns:** list with: $plots:  sch_outside_pct_lower_plot, sch_dept_pct_lower_plot, sch_top_majors_lower_plot, sch_outside_pct_upper_plot, sch_dept_pct_upper_plot, sch_top_majors_upper_plot, sch_outside_pct_plot, sch_dept_pct_plot $tables: credit_hours_data_w, sch_major_trends_lower, sch_outside_full_lower, sch_major_trends_upper, sch_outside_full_upper
 
 ---
 
-### `credit_hours_by_fac()`
+### `plot_chd_by_fac_faceted()`
 
 *Source: credit-hours.R*
 
-**Credit Hours By Faculty**
+**Credit Hours by Faculty Category**
 
-Credit Hours By Faculty  Analyzes credit hours taught by different faculty job categories. Shows credit hour production broken down by faculty type (tenure track, lecturer, etc.).
+Credit Hours by Faculty Category  Shows how SCH production is distributed across faculty job categories — tenure-track, lecturer, adjunct, etc. Requires the cedar_faculty table, which is built from HR data and is not always available.
 
 **Parameters:**
 
-- `data_objects` - List containing: - class_lists: CEDAR student enrollments - cedar_faculty: CEDAR faculty data with job_category
-- `d_params` - Department parameters list containing: - dept_code: Department code to filter - term_start: Starting term (inclusive) - term_end: Ending term (inclusive) - subj_codes: Subject codes for plot titles - palette: Color palette for plots
+- `data_objects` - List containing cedar_students and cedar_faculty
+- `dept_code` - Department code
+- `subj_codes` - Subject codes for plot titles
+- `term_start,term_end` - Integer term codes (inclusive)
+- `palette` - RColorBrewer palette name
 
-**Returns:** d_params list with added plots: - chd_by_fac_facet_plot: Bar chart faceted by course level - chd_by_fac_plot: Stacked bar chart of total credit hours
-
-**Details:**
-
-CEDAR-only function - requires CEDAR column names: - In class_lists: final_grade, term, department, campus, college, level, credits, instructor_id - In cedar_faculty: term, instructor_id, department, job_category
-
-**Example:**
-```r
-\dontrun{
-d_params <- credit_hours_by_fac(data_objects, d_params)
-}
-```
+**Returns:** list($plots): chd_by_fac_facet_plot (breakdown by level), chd_by_fac_plot (totals stacked by job category)
 
 ---
 
@@ -130,89 +753,19 @@ d_params <- credit_hours_by_fac(data_objects, d_params)
 
 *Source: credit-hours.R*
 
-**Get Credit Hours for Department Report**
+**Credit Hours for Department Report**
 
-Get Credit Hours for Department Report  Main function for credit hours analysis in department reports. Creates multiple plots and tables analyzing credit hour production.
-
-**Parameters:**
-
-- `class_lists` - Data frame of student enrollments (CEDAR format) Must contain columns: final_grade, term, campus, college, department, level, subject_code, credits
-- `d_params` - Department parameters list containing: - term_start: Starting term (inclusive) - term_end: Ending term (inclusive) - dept_code: Department code to filter - subj_codes: Subject codes for filtering - palette: Color palette for plots
-
-**Returns:** d_params list with added elements: - plots$college_credit_hours_plot: Bar chart of college credit hours - plots$college_credit_hours_comp_plot: Department vs college comparison - plots$college_dept_dual_plot: Dual y-axis comparison plot - plots$chd_by_year_facet_subj_plot: Credit hours faceted by subject - plots$chd_by_year_subj_plot: Credit hours stacked by subject - plots$chd_by_period_plot: Credit hours by course level - tables$chd_by_period_table: Credit hours table by period
-
-**Details:**
-
-CEDAR-only function - requires CEDAR column names: - term (not `Academic Period Code`) - campus (not `Course Campus Code`) - college (not `Course College Code`) - department (not DEPT) - subject_code (not `Subject Code`) - All lowercase with underscores
-
-**Example:**
-```r
-\dontrun{
-d_params <- get_credit_hours_for_dept_report(class_lists, d_params)
-}
-```
-
----
-
-## datatable_helpers
-
-### `apply_column_colors()`
-
-*Source: datatable_helpers.R*
-
-**Apply color coding to a column using preset or custom scheme**
+Credit Hours for Department Report  Produces the full set of department-level SCH plots: how the department compares to its college over time, broken down by subject code and level.
 
 **Parameters:**
 
-- `dt` - A DT::datatable object
-- `column` - Character string of column name to color code
-- `scheme` - Character name of preset scheme OR list with thresholds/colors/reverse_scale
-- `bold` - Logical, if TRUE makes the column text bold
+- `class_lists` - cedar_students data frame (full — not pre-filtered to dept)
+- `dept_code` - Department code (e.g., "BIOL")
+- `subj_codes` - Subject codes used in plot titles (informational only)
+- `term_start,term_end` - Integer term codes for the analysis window (inclusive)
+- `palette` - RColorBrewer palette name for bar chart colors
 
-**Returns:** Modified datatable object with color formatting applied
-
-**Example:**
-```r
-# Using preset scheme
-dt %>% apply_column_colors("avail", "availability")
-
-# Using custom scheme
-dt %>% apply_column_colors("my_col", list(
-  thresholds = c(10, 20),
-  colors = c('red', 'yellow', 'green'),
-  reverse_scale = FALSE
-))
-```
-
----
-
-### `create_styled_datatable()`
-
-*Source: datatable_helpers.R*
-
-**Create a styled datatable with automatic color coding**
-
-Create a styled datatable with automatic color coding  Applies color schemes based on column names matching preset patterns. Can also accept custom column-to-scheme mappings.
-
-**Parameters:**
-
-- `data` - Data frame to display
-- `column_schemes` - Named list mapping column names to scheme names or NULL for auto-detection
-- `pageLength` - Integer, number of rows per page (default 50)
-
-**Returns:** Styled datatable object
-
-**Example:**
-```r
-# Auto-detect columns
-create_styled_datatable(my_data)
-
-# Custom mappings
-create_styled_datatable(my_data, column_schemes = list(
-  "seats_left" = "availability",
-  "students" = "enrollment"
-))
-```
+**Returns:** list with: $plots:  college_credit_hours_plot, college_credit_hours_comp_plot, college_dept_dual_plot, chd_by_year_facet_subj_plot, chd_by_year_subj_plot, chd_by_period_plot $tables: chd_by_period_table
 
 ---
 
@@ -224,17 +777,17 @@ create_styled_datatable(my_data, column_schemes = list(
 
 **Count Degrees Awarded**
 
-Count Degrees Awarded  Counts degrees awarded by term, major, and degree type. Filters for relevant programs using the major_to_program and handles both first and second majors.
+Count Degrees Awarded  Counts degrees awarded by term and degree type for deduplication purposes.
 
 **Parameters:**
 
-- `degrees_data` - Data frame with degree award data (CEDAR naming conventions). Must include columns: term, student_id, student_college, department, program_code, award_category, degree, major, major_code, second_major, first_minor, second_minor.
+- `degrees_data` - Data frame with degree award data (CEDAR naming conventions). Must include columns: term, student_id, student_college, department, program_code, major_code, award_category, degree, major, second_major, first_minor, second_minor.
 
 **Returns:** Data frame with columns: - `term` (integer) - Term code - `major` (string) - Major name - `degree` (string) - Degree type (BA, BS, MA, MS, PhD, etc.) - `majors` (integer) - Count of degrees awarded
 
 **Details:**
 
-This function: 1. Selects relevant columns from degrees data 2. Removes duplicate rows (due to student attributes in source data) 3. Filters for programs defined in major_to_program 4. Counts degrees by term, major, and degree type  The function intentionally does NOT filter by college to capture students from other colleges who have an A&S program as a second major, certificate, etc.  **Note:** Summarization uses the `major` field rather than `major_code` to avoid variations like "PSY" vs "PSYC". The major field is more reliable due to standardized mappings.  **TODO:** Currently optimized for A&S degrees. Make useful for all colleges. **TODO:** Determine handling of minors, certificates, and other non-degree programs.
+This function: 1. Selects relevant columns from degrees data 2. Removes duplicate rows (due to student attributes in source data) 3. Counts degrees by term, major_code, and degree type  The function intentionally does NOT filter by college to capture students from other colleges who have an A&S program as a second major, certificate, etc.  **Note:** Summarization uses `major_code` for grouping. Downstream filtering in `get_degrees_for_dept_report()` filters by `major_code %in% prog_codes` to restrict mappings.  **TODO:** Currently optimized for A&S degrees. Make useful for all colleges. **TODO:** Determine handling of minors, certificates, and other non-degree programs.
 
 **Example:**
 ```r
@@ -266,122 +819,55 @@ Generate Degree Visualizations for Department Report  Prepares degree analysis d
 **Parameters:**
 
 - `degrees_data` - Data frame with degree award data (CEDAR naming conventions). See `count_degrees()` for required columns.
-- `d_params` - List containing department report parameters. Required fields: - `term_start` (integer) - Starting term code (e.g., 201980) - `term_end` (integer) - Ending term code (e.g., 202580) - `prog_names` (character vector) - Program names to include (e.g., c("Mathematics", "Physics")) - `prog_codes` (character vector) - Program codes for plot titles - `dept_name` (string) - Department name for plot titles - `palette` (string) - ColorBrewer palette name for plots - `plots` (list) - Existing plots list (will be updated) - `tables` (list) - Existing tables list (will be updated)
+- `dept_name` - Character. Department name for plot titles.
+- `prog_codes` - Character vector. Program (major) codes to filter by (e.g., c("MATH", "AMAT")).
+- `term_start` - Integer. Starting term code for filtering (e.g., 201980).
+- `term_end` - Integer. Ending term code for filtering (e.g., 202580).
+- `palette` - Character. ColorBrewer palette name for plots (e.g., "Set2").
 
-**Returns:** Updated d_params list with new plots and tables added:  **Plots added:** - `degree_summary_faceted_by_major_plot` - Faceted line chart showing degrees awarded over time for each major/degree type combination - `degree_summary_filtered_program_stacked_plot` - Stacked bar chart showing total degrees awarded by degree type across all programs  **Tables added:** - `degree_summary_filtered_program` - Summary table with columns: term, degree, majors_total
+**Returns:** List with structure: list( plots  = list(degree_summary_faceted_by_major_plot, degree_summary_filtered_program_stacked_plot), tables = list(degree_summary_filtered_program) )
 
 **Details:**
 
-This function: 1. Calls `count_degrees()` to get degree counts 2. Filters by term range (term_start to term_end) 3. Filters by program names from d_params 4. Creates faceted line chart (one facet per major) 5. Creates stacked bar chart (aggregated across programs) 6. Adds plots and tables to d_params object  **Visualizations:** - **Faceted line chart**: Shows trends for each major separately, colored by degree type. Useful for seeing how individual programs grow/shrink over time. - **Stacked bar chart**: Shows overall degree production by type, aggregated across all programs. Useful for seeing department-wide trends.  Both plots are converted to interactive plotly objects for better exploration.
+This function: 1. Calls `count_degrees()` to get degree counts 2. Filters by term range 3. Filters by prog_codes (major_code) 4. Creates faceted line chart (one facet per major) 5. Creates stacked bar chart (aggregated across programs)  Both plots are converted to interactive plotly objects for better exploration.
 
 **Example:**
 ```r
 \dontrun{
-# Load data
 degrees <- readRDS(paste0(cedar_data_dir, "cedar_degrees.Rds"))
-
-# Set up parameters
-d_params <- list(
-  term_start = 201980,
-  term_end = 202580,
-  prog_names = c("Mathematics", "Applied Mathematics"),
+result <- get_degrees_for_dept_report(
+  degrees,
+  dept_name  = "Mathematics & Statistics",
   prog_codes = c("MATH", "AMAT"),
-  dept_name = "Mathematics & Statistics",
-  palette = "Set2",
-  plots = list(),
-  tables = list()
+  prog_codes = c("Mathematics", "Applied Mathematics"),
+  term_start = 201980,
+  term_end   = 202580,
+  palette    = "Set2"
 )
-
-# Generate visualizations
-d_params <- get_degrees_for_dept_report(degrees, d_params)
-
-# Access outputs
-faceted_plot <- d_params$plots$degree_summary_faceted_by_major_plot
-stacked_plot <- d_params$plots$degree_summary_filtered_program_stacked_plot
-degree_table <- d_params$tables$degree_summary_filtered_program
+result$plots$degree_summary_faceted_by_major_plot
+result$tables$degree_summary_filtered_program
 }
 
 ```
 
 ---
 
-## dept-report
+## demographics
 
-### `set_payload()`
+### `summarize_student_demographics()`
 
-*Source: dept-report.R*
+*Source: demographics.R*
 
-**Initialize Department Report Parameters**
+**Summarize Student Demographics**
 
-Initialize Department Report Parameters  Creates the d_params structure with department metadata, program mappings, and empty containers for tables and plots. This is the first step in department report generation.
-
-**Parameters:**
-
-- `dept_code` - Character. Department code (e.g., "HIST", "MATH")
-- `prog_focus` - Character or NULL. Optional program code to focus on a specific program within the department (e.g., "HIST" for History major only)
-
-**Returns:** List containing: - `dept_code` - Department code - `dept_name` - Full department name - `subj_codes` - Subject codes associated with department - `prog_focus` - Program focus (if specified) - `prog_names` - Program names from major_to_program - `prog_codes` - Program codes - `tables` - Empty list (will be populated by cone functions) - `plots` - Empty list (will be populated by cone functions) - `term_start` - Start term from config - `term_end` - End term from config - `palette` - Color palette from config
-
-**Details:**
-
-Uses global mapping variables: - `prgm_to_dept_map` - Maps program codes to departments - `major_to_program` - Maps major names to program codes - `subj_to_dept` - Maps subject codes to departments - `dept_code_to_name` - Maps department codes to full names
-
-**Example:**
-```r
-\dontrun{
-# All programs in History department
-d_params <- set_payload("HIST")
-
-# Focus on specific program
-d_params <- set_payload("HIST", prog_focus = "HIST")
-}
-
-```
-
----
-
-### `create_dept_report_data()`
-
-*Source: dept-report.R*
-
-**Generate Department Report Data (Interactive)**
-
-Generate Department Report Data (Interactive)  Generates all tables and plots for department reports by calling individual cone functions (headcount, degrees, credit hours, grades, enrollment, SFR). This function is used by the Shiny app for interactive report generation.
+Summarize Student Demographics  Flexible demographic summary function that groups students by any specified columns (majors, classifications, or other demographic fields) and calculates enrollment counts, means across terms, and percentages of course enrollment. This provides insight into "who" is taking courses over time.  Lives in branches/ because it is consumed by multiple cones (course-demographics.R and waitlist.R).
 
 **Parameters:**
 
-- `data_objects` - List containing required data sources: - `academic_studies` - Student program enrollment (headcount) - `degrees` - Graduate data with CEDAR naming (cedar_degrees) - `class_lists` - Course enrollment data (credit hours, grades) - `cedar_faculty` - Faculty HR data with CEDAR naming (SFR, DFW analysis) - `DESRs` - Demand-enrollment data (enrollment trends)
-- `opt` - Options list with: - `dept` (required) - Department code (e.g., "HIST") - `prog` (optional) - Program focus code - `shiny` (optional) - Boolean indicating Shiny context
+- `filtered_students` - Data frame of student enrollments from cedar_students table, already filtered by desired criteria. Must include: student_id, term, campus, college, subject_course, and any demographic columns used in grouping.
+- `opt` - Options list containing: \itemize{ \item \code{group_cols} - Character vector of column names to group by. If NULL, uses default: campus, college, term, term_type, major, student_classification, subject_course, course_title, level }
 
-**Returns:** d_params list with populated tables and plots: - All fields from `set_payload()` - `tables` - Named list of data frames from all analyses - `plots` - Named list of plotly/ggplot objects from all analyses
-
-**Details:**
-
-**Processing workflow:** 1. Calls `set_payload()` to initialize structure 2. Headcount: `get_headcount_data_for_dept_report()` 3. Degrees: `get_degrees_for_dept_report()` 4. Credit Hours: `get_credit_hours_for_dept_report()`, `credit_hours_by_major()`, `credit_hours_by_fac()` 5. Grades: `get_grades_for_dept_report()` (DFW analysis) 6. Enrollment: `get_enrl_for_dept_report()` 7. SFR: `get_sfr_data_for_dept_report()`  **CEDAR Migration Notes:** - Uses CEDAR dataset keys exclusively: cedar_faculty, cedar_students, cedar_programs, cedar_sections, cedar_degrees - No legacy fallbacks; all data must be in CEDAR format with lowercase column names - Requires `department` column (CEDAR) in cedar_students for filtering  **Typical outputs include:** - Headcount tables/plots by program and level - Degree award trends by major and type - Credit hour production by term - DFW rates by course and instructor type - Enrollment trends by term type - Student-faculty ratios over time
-
-**Example:**
-```r
-\dontrun{
-# Load data (CEDAR naming only)
-data_objects <- list(
-  cedar_programs = readRDS(paste0(cedar_data_dir, "cedar_programs.Rds")),
-  cedar_degrees = readRDS(paste0(cedar_data_dir, "cedar_degrees.Rds")),
-  cedar_students = readRDS(paste0(cedar_data_dir, "cedar_students.Rds")),
-  cedar_faculty = readRDS(paste0(cedar_data_dir, "cedar_faculty.Rds")),
-  cedar_sections = readRDS(paste0(cedar_data_dir, "cedar_sections.Rds"))
-)
-
-# Generate report data
-opt <- list(dept = "HIST", shiny = TRUE)
-d_params <- create_dept_report_data(data_objects, opt)
-
-# Access outputs
-names(d_params$tables)
-names(d_params$plots)
-d_params$plots$degree_summary_faceted_by_major_plot
-}
-
-```
+**Returns:** Data frame with student demographic breakdown including: \describe{ \item{count}{Number of distinct students in this group for THIS SPECIFIC TERM} \item{mean}{Average count across all terms OF THE SAME TERM_TYPE (e.g., avg across all falls). This is the key value used for plotting "average students per term type".} \item{registered}{Total course enrollment for this specific term} \item{registered_mean}{Average course enrollment across terms of same term_type} \item{term_pct}{Percentage of course enrollment this group represents IN THIS TERM (count / registered * 100)} \item{term_type_pct}{AVERAGE percentage across all terms of this term_type (mean / registered_mean * 100). This is what the pie charts display.} } Plus all columns specified in group_cols.  The \code{mean} and \code{term_type_pct} columns answer: "On average, what percentage of students in HIST 1105 are freshmen in fall semesters?" This averages across Fall 2022, Fall 2023, Fall 2024, etc. to give a stable "typical" value.
 
 ---
 
@@ -419,7 +905,7 @@ courses_compressed <- compress_aop_pairs(courses_filtered, opt)
 
 ---
 
-### `summarize_courses()`
+### `sum_xl_dedup_total()`
 
 *Source: enrl.R*
 
@@ -431,8 +917,11 @@ Summarize Courses by Grouping Columns  Generic summary function that aggregates 
 
 - `courses` - Data frame of course sections. Must include columns used in grouping plus: enrolled, crosslist_code, available, waitlist_count
 - `opt` - Options list containing: \itemize{ \item \code{group_cols} - Character vector of column names to group by. If NULL, uses default: campus, college, term, term_type, subject, subject_course, course_title, level, gen_ed_area }
+- `own` - Per-row own enrollment, used for rows with no crosslist group.
+- `group_total` - Per-row crosslist-combined enrollment (total_enrl).
+- `xl_key` - Crosslist group key (e.g. "term|campus|code"); NA for non-crosslisted rows.
 
-**Returns:** Data frame summarized by group_cols with columns: \describe{ \item{sections}{Total number of sections in group} \item{xl_sections}{Number of crosslisted sections (crosslist_code != "0")} \item{reg_sections}{Number of regular (non-crosslisted) sections} \item{avg_size}{Average enrollment per section (rounded to 1 decimal)} \item{enrolled}{Total enrollment across all sections} \item{avail}{Total available seats across all sections} \item{waiting}{Total waitlist count across all sections} } Plus all columns specified in group_cols.
+**Returns:** Data frame summarized by group_cols with columns: \describe{ \item{sections}{Total number of sections in group} \item{xl_sections}{Number of crosslisted sections (crosslist_code != "0")} \item{reg_sections}{Number of regular (non-crosslisted) sections} \item{avg_size}{Average enrollment per section (rounded to 1 decimal)} \item{total_enrl}{Crosslist-aware total: each crosslist group's combined enrollment counted once, plus own enrollment of non-crosslisted sections. For a cross-course crosslist this includes partner-course students, so it can exceed \code{enrolled}.} \item{enrolled}{Total enrollment across all sections (own students only)} \item{avail}{Total available seats across all sections} \item{waiting}{Total waitlist count across all sections} } Plus all columns specified in group_cols.
 
 **Details:**
 
@@ -449,6 +938,21 @@ summary <- summarize_courses(cedar_sections, opt)
 opt <- list(group_cols = NULL)  # Uses default
 summary <- summarize_courses(cedar_sections, opt)
 }
+
+Course-level total enrollment with each crosslist group counted once
+
+Every section row in a crosslist group carries the group's combined
+enrollment in total_enrl (transform-to-cedar.R sets it to
+pmax(ENROLLED, XL_TOTAL_ENROLLMENT)). Summing total_enrl over the rows of a
+group therefore multiply-counts it — once per section. A same-course
+internal group of 4 sections sharing a combined total of 96 sums to 384
+(this is what made BIOL 2305 report ~4x its real enrollment).
+
+Within one aggregation cell, count each crosslist group's combined total
+once (max over the group's identical values) and use each non-crosslisted
+row's own enrollment. Cross-course groups keep their intended semantics:
+each course's cell contains its own rows of the group, so each course sees
+the combined total once.
 
 ```
 
@@ -481,30 +985,27 @@ This is primarily a validation wrapper. It stops execution with an error if grou
 
 **Get Enrollment Summary and Plots for Department Report**
 
-Get Enrollment Summary and Plots for Department Report  Creates enrollment analysis and visualizations for department reports. Aggregates enrollment data by course, generates top enrollment charts, and produces class size distribution histograms. The plots are added to the d_params object for use in automated department reports.
+Get Enrollment Summary and Plots for Department Report  Creates enrollment analysis and visualizations for department reports. Aggregates enrollment data by course, generates top enrollment charts, and produces class size distribution histograms.
 
 **Parameters:**
 
 - `courses` - Data frame of course sections from cedar_sections table.
-- `d_params` - Department parameters list containing: \itemize{ \item \code{dept_code} - Department code to analyze \item \code{palette} - Color palette for plots (e.g., "Set2", "Dark2") \item \code{plots} - Named list where enrollment plots will be added }
+- `dept_code` - Character. Department code to analyze (e.g., "ENGL").
+- `palette` - Character. ColorBrewer palette name for plots (e.g., "Set2", "Dark2").
+- `term_start` - Integer. First term code to include (e.g., 201980). Fall/spring only — summers are excluded regardless.
+- `term_end` - Integer. Last term code to include (e.g., 202480).
 
-**Returns:** Modified d_params list with three new plots added to d_params$plots: \itemize{ \item \code{highest_total_enrl_plot} - Bar chart of top 10 courses by total enrollment \item \code{highest_mean_enrl_plot} - Bar chart of top 10 courses by average section size \item \code{highest_mean_histo_plot} - Histogram of average class sizes by course level }
+**Returns:** List with structure: list( plots  = list(highest_total_enrl_plot, highest_mean_enrl_plot, highest_mean_histo_plot), tables = list() )
 
 **Details:**
 
-This function performs the following steps: \enumerate{ \item Builds opt list with department filter and default grouping columns \item Calls \code{get_enrl()} to filter and aggregate enrollment data \item Identifies top 10 courses by total and average enrollment \item Creates bar charts for highest enrollment courses \item Creates histogram of class size distribution by level \item Converts histogram to interactive plotly widget \item Adds all plots to d_params$plots list }  Default grouping columns are: subject, subject_course, course_title, level, gen_ed_area  Note: AOP (All Online Programs) courses are compressed by default (opt$x = "compress").
+This function performs the following steps: \enumerate{ \item Strips summer terms from the sections data \item Builds opt list with department filter, term range, and default grouping columns \item Calls \code{get_enrl()} to filter and aggregate enrollment data \item Identifies top 10 courses by total and average enrollment \item Creates bar charts for highest enrollment courses \item Creates histogram of class size distribution by level \item Converts histogram to interactive plotly widget }  Default grouping columns are: subject, subject_course, course_title, level, gen_ed_area  Note: AOP (All Online Programs) courses are compressed by default (opt$x = "compress").
 
 **Example:**
 ```r
 \dontrun{
-# Typical usage in department report workflow
-d_params <- list(
-  dept_code = "ENGL",
-  palette = "Set2",
-  plots = list()
-)
-d_params <- get_enrl_for_dept_report(cedar_sections, d_params)
-# d_params$plots now contains three enrollment visualizations
+result <- get_enrl_for_dept_report(cedar_sections, "ENGL", "Set2", 201980, 202480)
+result$plots$highest_total_enrl_plot
 }
 
 ```
@@ -627,7 +1128,7 @@ compressed_data <- get_enrl(cedar_sections, opt)
 
 ---
 
-### `get_low_enrollment_courses()`
+### `get_course_section_counts()`
 
 *Source: enrl.R*
 
@@ -640,8 +1141,36 @@ Get courses below enrollment threshold  Identifies courses with enrollment below
 - `courses` - Data frame of course sections (DESRs)
 - `opt` - Options list with filtering parameters
 - `threshold` - Numeric enrollment threshold (default 15)
+- `sections` - Data frame of course sections (cedar_sections). Must include: status, crosslist_group, crosslist_primary, term, subject_course, course_title, campus, total_enrl.
 
-**Returns:** Data frame of low-enrollment courses with enrollment history
+**Returns:** Data frame with columns: \itemize{ \item \code{term} — term code \item \code{subject_course} — e.g. "HIST 1110" \item \code{course_title} — full course title (needed to distinguish topics courses) \item \code{campus} — campus code \item \code{n_sections} — count of active home sections \item \code{course_enrl} — sum of total_enrl across those sections }
+
+**Example:**
+```r
+counts <- get_course_section_counts(cedar_sections)
+low_enrl <- low_enrl %>%
+  left_join(counts, by = c("term", "subject_course", "course_title", "campus")) %>%
+  mutate(n_sections = coalesce(n_sections, 1L),
+         course_enrl = coalesce(course_enrl, total_enrl))
+```
+
+---
+
+### `get_enrollment_concerns()`
+
+*Source: enrl.R*
+
+**Get enrollment concerns for a future term**
+
+Get enrollment concerns for a future term  Analyzes a future term's scheduled courses against historical enrollment patterns from prior terms of the same type (fall/spring/summer). Returns each scheduled course with its historical average enrollment, trend, and history text for display in the concerns tab.
+
+**Parameters:**
+
+- `courses` - Data frame of course sections (cedar_sections)
+- `opt` - Options list with filters (term, course_campus, dept, etc.)
+- `n_history_terms` - Number of prior same-type terms to average (default 4)
+
+**Returns:** Data frame with schedule + historical stats per course
 
 ---
 
@@ -683,50 +1212,26 @@ Create enrollment history string for display  Generates a text representation of
 
 ---
 
-## filter
+## gened-fulfillment
 
-### `filter_by_term()`
+### `make_gened_fulfillment()`
 
-*Source: filter.R*
+*Source: gened-fulfillment.R*
 
-**Filter a Data Frame by Term(s)**
-
-Filter a Data Frame by Term(s)  Filters rows in a data frame to include only those matching the specified term or terms in a given column.
+**Plot gen ed fulfillment for a department's graduates**
 
 **Parameters:**
 
-- `df` - A data frame to filter.
-- `term` - A single term value or a vector of term values to filter by (e.g., "202510" or c("202510", "202520")).
-- `term_col` - The name of the column in `df` containing term values. Default is "TERM".
+- `students` - cedar_students data frame
+- `degrees` - cedar_degrees data frame
+- `dept_code` - Department code (e.g., "HIST", "GES")
+- `degree_abbr` - Optional degree filter (e.g., "BA", "BS"). NULL = all degrees. Useful when a dept offers both BA and BS to compare gen ed patterns by degree type.
+- `major_code` - Optional program filter matching major_dept_map$major_code (e.g., "ASTR" within dept "PHYS"). NULL = all programs in the dept. Useful when a dept contains distinct programs that have different gen ed patterns.
+- `min_grad_term` - Earliest graduation term to include (default 202310 = Spring 2023). Students who graduated before this term may have incomplete enrollment histories.
+- `campuses` - Campus codes to include; NULL = all campuses
+- `return_data` - If TRUE, return a list of intermediate data frames instead of the plot. Useful for debugging: list contains $grads, $gen_ed_enrls, $plot_df.
 
-**Returns:** A filtered data frame containing only rows where `term_col` matches one of the values in `term`.
-
-**Example:**
-```r
-# Filter for a single term:
-filter_by_term(df, "202510")
-# Filter for multiple terms:
-filter_by_term(df, c("202510", "202520"))
-# Specify a custom term column:
-filter_by_term(df, "202510", term_col = "Academic Period Code")
-```
-
----
-
-### `filter_data()`
-
-*Source: filter.R*
-
-**Generic filter for a MyReports data frame.**
-
-**Parameters:**
-
-- `df` - The data frame to filter (DESRs or class list).
-- `opt` - The options list.
-- `opt_col_map` - Named list mapping opt param names to column names in df.
-- `special_filters` - (Optional) Named list of functions for special-case filtering.
-
-**Returns:** Filtered data frame.
+**Returns:** ggplot stacked bar chart, or list of data frames if return_data = TRUE
 
 ---
 
@@ -792,7 +1297,7 @@ categorized <- categorize_grades(grade_counts, group_cols, passing_grades)
 
 **Calculate DFW Percentage**
 
-Calculate DFW Percentage  Adds dfw_pct column to categorized grade data. Formula: dfw_pct = failed / (passed + failed) * 100
+Calculate DFW Percentage  Adds dfw_pct column to categorized grade data. Formula: dfw_pct = (failed + late_dropped) / (passed + failed + late_dropped) * 100
 
 **Parameters:**
 
@@ -824,13 +1329,13 @@ Prepare Student Data for Grade Analysis  Filters and preprocesses student enroll
 **Parameters:**
 
 - `students` - Data frame from cedar_students table
-- `opt` - Options list for filtering (passed to filter_class_list)
+- `opt` - Options list for filtering (passed to filter_class_list). Also supports: \itemize{ \item \code{cohort_ids} - Character vector of student IDs. If provided, analysis is restricted to these students after all other filters are applied. Use with cohorts built by \code{build_cohort()} in cohort.R. }
 
 **Returns:** Data frame of prepared students ready for grade counting, or empty data frame if no students match filters
 
 **Details:**
 
-Preprocessing steps: \enumerate{ \item Filter students using filter_class_list() with provided options \item Restrict to Fall 2019 or later (term >= 201980, after Gen Ed implementation) \item Convert DR (Drop) registration status to "Drop" final grade \item Remove duplicate student records per section (by student_id, campus, college, crn) \item Merge with grades_to_points lookup table for grade point values }
+Preprocessing steps: \enumerate{ \item Filter students using filter_class_list() with provided options \item If opt$population_ids is provided, restrict to those students \item Restrict to Fall 2019 or later (term >= 201980, after Gen Ed implementation) \item Convert DR (Drop) registration status to "Drop" final grade \item Remove duplicate student records per section (by student_id, campus, college, crn) \item Merge with grades_to_points lookup table for grade point values }
 
 **Example:**
 ```r
@@ -855,7 +1360,7 @@ Merge Faculty Job Category Data with Grade Counts  Adds instructor job category 
 - `grade_counts` - Data frame with grade counts including instructor_id and term
 - `cedar_faculty` - Data frame from cedar_faculty table with job_category
 
-**Returns:** grade_counts with job_category column added (if merge successful), or original grade_counts if no matches found (non-A&S units)
+**Returns:** grade_counts with job_category column added
 
 **Example:**
 ```r
@@ -890,6 +1395,35 @@ aggregations <- build_aggregation_list(dfw_summary, grade_counts)
 
 ---
 
+### `add_instructor_type()`
+
+*Source: gradebook.R*
+
+**Add Instructor Type to Grade Data**
+
+Add Instructor Type to Grade Data  Enriches a grades list (from get_grades()) with instructor job category (TT/NTT) from HR data, and adds the inst_type aggregation table grouped by job_category.
+
+**Parameters:**
+
+- `grades` - Named list returned by get_grades()
+- `cedar_faculty` - Data frame from cedar_faculty table with instructor_id, term, job_category
+
+**Returns:** grades list with job_category added to counts/dfw_summary and inst_type table added
+
+**Details:**
+
+cedar_faculty only contains CAS departments. For non-CAS units (e.g. Nursing), this function will stop() since no faculty records will match. Only call this function when faculty data is available for the departments being analyzed.
+
+**Example:**
+```r
+\dontrun{
+grades <- get_grades(cedar_students, opt)
+grades <- add_instructor_type(grades, cedar_faculty)
+}
+```
+
+---
+
 ### `aggregate_grades()`
 
 *Source: gradebook.R*
@@ -915,35 +1449,35 @@ This function validates that all requested group_cols exist in the data before a
 
 *Source: gradebook.R*
 
-**Get Grade Data and Calculate DFW Statistics**
+**Get Legacy Gradebook Report Bundle**
 
-Get Grade Data and Calculate DFW Statistics  Main controller function for grade analysis. Filters student enrollment data, calculates DFW (Drop/Fail/Withdraw) statistics, merges with CEDAR faculty data for instructor categorization, and produces multiple aggregated views of grade data.
+Get Legacy Gradebook Report Bundle  Legacy/report facade for grade analysis. New cones should use \code{get_course_outcome_rates()} for DFW/outcome metrics or \code{get_grade_distribution()} for letter-grade distributions unless they explicitly need this full report bundle.  This function preserves the existing report contract while delegating row-level cleanup to \code{prepare_course_attempts()}.
 
 **Parameters:**
 
 - `students` - Data frame from cedar_students table with columns: student_id, campus, college, term, crn, subject_course, final_grade, registration_status_code, instructor_last_name, instructor_id
-- `cedar_faculty` - Data frame from cedar_faculty table with columns: instructor_id, term, job_category
 - `opt` - Options list for filtering and grouping: \itemize{ \item \code{course} - Course identifier(s) to filter by \item \code{dept} - Department code to filter by \item \code{term} - Term code(s) to filter by \item Other filter options supported by \code{filter_class_list()} }
 
-**Returns:** Named list with grade data at various aggregation levels: \describe{ \item{counts}{Grade counts by campus, college, term, course, instructor, grade} \item{dfw_summary}{DFW summary with passed, failed, early_dropped, late_dropped counts} \item{course_inst_avg}{Averages by course and instructor (across all terms)} \item{inst_type}{Averages by course, term, and instructor type (job_cat)} \item{course_term}{Averages by course and term} \item{course_avg}{Overall course averages (across all terms)} \item{course_avg_by_term}{Course averages for each individual term} }
+**Returns:** Named list with grade data at various aggregation levels: \describe{ \item{counts}{Grade counts by campus, college, term, course, instructor, grade} \item{dfw_summary}{DFW summary with passed, failed, early_dropped, late_dropped counts} \item{course_inst_avg}{Averages by course and instructor (across all terms)} \item{course_term}{Averages by course and term} \item{course_avg}{Overall course averages (across all terms)} \item{course_avg_by_term}{Course averages for each individual term} } Call \code{add_instructor_type(grades, cedar_faculty)} on the result to add \code{inst_type} (TT/NTT breakdown) when faculty data is available.
 
 **Details:**
 
-The function performs the following workflow: \enumerate{ \item Filters students using \code{filter_class_list()} with provided options \item Restricts to Fall 2019 or later (after Gen Ed implementation: term >= 201980) \item Converts DR (Drop) registration status to "Drop" final grade \item Removes duplicate student records per section \item Merges with grades_to_points lookup table \item Summarizes grade counts by campus, college, term, course, instructor \item Merges with HR data to add instructor job category (job_cat) \item Separates grades into passed, failed, early drops, and late drops \item Calculates DFW percentage: failed/(passed+failed)*100 \item Produces multiple aggregated views using \code{aggregate_grades()} \item Adds section counts per instructor }  **Important**: DFW % calculation excludes early drops (DR status) since those students are not counted in enrollment totals.  Passing grades are defined in includes/lists.R (typically A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, S, CR)
+The function performs the following workflow: \enumerate{ \item Filters students using \code{filter_class_list()} with provided options \item Restricts to Fall 2019 or later (after Gen Ed implementation: term >= 201980) \item Converts DR (Drop) registration status to "Drop" final grade \item Removes duplicate student records per section \item Merges with grades_to_points lookup table \item Summarizes grade counts by campus, college, term, course, instructor \item Separates grades into passed, failed, early drops, and late drops \item Calculates DFW percentage: failed/(passed+failed)*100 \item Produces multiple aggregated views using \code{aggregate_grades()} \item Adds section counts per instructor }  To add instructor type (TT/NTT) breakdowns, call \code{add_instructor_type(grades, cedar_faculty)} on the result. This is a separate step because faculty data is only available for CAS departments.  **Important**: DFW % calculation excludes early drops (DR status) since those students are not counted in enrollment totals.  Passing grades are defined in includes/lists.R (typically A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, S, CR)
 
 **Example:**
 ```r
 \dontrun{
 # Get grades for a specific course
 opt <- list(course = "MATH 1430", term = 202510)
-grades <- get_grades(cedar_students, cedar_faculty, opt)
+grades <- get_grades(cedar_students, opt)
 
 # View DFW summary
 head(grades$dfw_summary)
 
-# Get grades for a department
+# Get grades for a department with instructor type breakdown
 opt <- list(dept = "HIST")
-dept_grades <- get_grades(cedar_students, cedar_faculty, opt)
+grades <- get_grades(cedar_students, opt)
+grades <- add_instructor_type(grades, cedar_faculty)  # CAS departments only
 }
 
 ```
@@ -952,7 +1486,7 @@ dept_grades <- get_grades(cedar_students, cedar_faculty, opt)
 
 ## headcount
 
-### `filter_programs_by_opt()`
+### `normalize_headcount_opt()`
 
 *Source: headcount.R*
 
@@ -963,13 +1497,13 @@ Filter Programs Data by Options  Helper function that applies institutional and 
 **Parameters:**
 
 - `programs` - Data frame of student program enrollment data (CEDAR format)
-- `opt` - Options list with possible filters: \itemize{ \item campus - Vector of campus codes to include \item college - Vector of college codes to include \item dept - Vector of department codes to include \item major - Vector of major program names to include \item major_codes - Vector of major program codes to include (preferred over major for reliability). Supports prefix matching: "HIST-BA", "HIST-MA" will also match minor code "HIST" \item minor - Vector of minor program names to include \item concentration - Vector of concentration names to include }
+- `opt` - Options list with possible filters: \itemize{ \item campus - Vector of campus codes to include \item college - Vector of college codes to include \item dept - Vector of department codes to include \item major - Vector of major program names to include \item minor - Vector of minor program names to include \item concentration - Vector of concentration names to include }
 
 **Returns:** List with: \describe{ \item{data}{Filtered data frame} \item{has_program_filter}{Boolean indicating if program-specific filters were applied} }
 
 **Details:**
 
-Applies filters in two stages: 1. Institutional filters (campus, college, department) 2. Program filters (major, minor, concentration)  Program filters are applied inclusively - they keep the specified programs while preserving other program types for the same students.
+**Filtering strategy**  Campus and college are row-level filters. Because these attributes are the same across all program rows for a student in a given term, row-level filtering is equivalent to student-level filtering and safe to apply directly.  Dept is a row-level filter: only program rows whose dept_code matches are kept. Cross-dept combinations (e.g. History major + Anthropology minor) are handled by using the major/minor/concentration filters directly instead of the dept filter.  Major, minor, and concentration each independently find the set of student IDs that satisfy that criterion, then intersect them. A student must satisfy every active program filter to be included (AND logic across filters). When multiple program filters are active, only rows for the primary filter are returned (major > minor > concentration), so the plot shows a single series rather than one facet per type.
 
 ---
 
@@ -985,13 +1519,14 @@ Summarize Headcount Data  Helper function that groups and counts students from f
 
 - `df` - Filtered programs data frame (from filter_programs_by_opt)
 - `has_program_filter` - Boolean indicating if program filters were applied
-- `group_by` - Character vector of column names to group by. Default: c("term", "student_level", "program_type", "program_name") For aggregate summaries, use: c("term", "student_level", "program_type")
+- `group_by` - Character vector of column names to group by. When NULL: - No program filter: groups by c("term", "student_level", "program_type") - Program filter active: groups by c("term", "student_level", "program_type", "program_name") Pass explicitly for custom aggregations (e.g. SFR: c("term", "dept_code", "student_level")).
+- `lookups` - Optional list with \code{program_name_lookup} (program_name → dept_code) and \code{dept_name_lookup} (dept_code → dept_name), used only to roll a broad program selection up to department totals (see Details).
 
-**Returns:** Data frame with columns based on group_by plus student_count
+**Returns:** Data frame with columns from group_by plus student_count (distinct student IDs)
 
 **Details:**
 
-If no program filters were applied, summarizes by program type only. If program filters were applied, includes program_name in grouping.
+**Department/unit rollup**  When no explicit \code{group_by} is given and a program filter selects more than \code{UNIT_ROLLUP_THRESHOLD} distinct programs (e.g. every major in a college), faceting one panel per program doesn't scale. In that case the data is regrouped by the program's owning department (via \code{program_name_lookup}) instead of by individual program, and \code{attr(result, "rolled_up_by_dept")} is set to TRUE so \code{\link{make_headcount_plots_by_level}} can facet/label by department.
 
 ---
 
@@ -1020,34 +1555,34 @@ Format Headcount Result with Metadata  Helper function that packages headcount d
 
 **Get Student Headcount**
 
-Get Student Headcount  Main function for calculating student headcount from CEDAR programs data. Flexible orchestrating function that filters, summarizes, and packages headcount data for various use cases.
+Get Student Headcount  Main orchestrating function for calculating student headcount from CEDAR programs data.
 
 **Parameters:**
 
-- `programs` - Student program enrollment data in CEDAR format. Required columns: student_id, term, student_level, program_type, program_name. Optional columns: student_college, student_campus, department, degree, program_code.
-- `opt` - Options list for filtering and behavior: \itemize{ \item campus - Filter by campus code(s) \item college - Filter by college code(s) \item dept - Filter by department code(s) \item major - Filter by major program name(s) \item major_codes - Filter by major program code(s) - PREFERRED over major for consistency. Uses prefix matching to include related minors/programs (e.g., "HIST" matches "HIST-BA", "HIST-MA") \item minor - Filter by minor program name(s) \item concentration - Filter by concentration name(s) }
-- `group_by` - Optional character vector of column names to group by. Default behavior groups by term, student_level, program_type, and program_name (if program filters applied) or just program_type (if no program filters). For custom aggregations (e.g., SFR), specify columns explicitly.
+- `programs` - Student program enrollment data in CEDAR format. Required columns: student_id, term, student_level, program_type, program_name, dept_code. Optional columns: student_college, student_campus, degree.
+- `opt` - Options list for filtering: \itemize{ \item campus - Filter by campus code(s) \item college - Filter by college code(s) \item dept - Filter by department code(s); scopes to students with any program in that dept, preserving their minor/concentration rows from other depts \item major - Filter by major program name(s) \item minor - Filter by minor program name(s) \item concentration - Filter by concentration name(s) } Multiple program filters (major + minor, etc.) are combined with AND logic: only students satisfying all specified filters are counted. The plot reflects the primary filter (major > minor > concentration).
+- `group_by` - Optional character vector of columns to group by. Defaults to c("term", "student_level", "program_type", "program_name") when a program filter is active, or c("term", "student_level", "program_type") otherwise. Pass explicitly for custom aggregations (e.g. SFR: c("term", "dept_code", "student_level")).
 
-**Returns:** List with headcount data and metadata: \describe{ \item{data}{Data frame with student_count column and grouping columns} \item{no_program_filter}{Boolean indicating if program-specific filters were applied} \item{metadata}{List with total_students, programs_included, filters_applied} }
+**Returns:** List with: \describe{ \item{data}{Data frame with student_count and grouping columns} \item{no_program_filter}{TRUE when no major/minor/concentration filter was applied} \item{metadata}{List with total_students, programs_included, filters_applied} }
 
 **Details:**
 
-**CEDAR Data Model Only**  This function requires CEDAR-formatted data with lowercase column names. No fallbacks to legacy naming - CEDAR is mandatory.  **Architecture:**  This is an orchestrating function that delegates to smaller helper functions: - \code{\link{filter_programs_by_opt}}: Applies filters - \code{\link{summarize_headcount}}: Groups and counts - \code{\link{format_headcount_result}}: Packages with metadata  **Workflow:** 1. Selects relevant CEDAR columns (student_id, term, program fields, etc.) 2. Applies institutional filters (campus, college, department) 3. Applies program filters (major, minor, concentration) 4. Groups and counts unique students 5. Returns structured result with metadata  **Use Cases:** - Department reports: Filter by dept/program, get detailed breakdown - SFR calculations: Specify custom group_by for aggregated counts - General headcount: No filters, get all programs  **Deprecated Functions:**  \code{count_heads_by_program()} is deprecated and now simply calls \code{get_headcount()}. Update your code to use \code{get_headcount()} directly.
+Delegates to \code{\link{filter_programs_by_opt}}, \code{\link{summarize_headcount}}, and \code{\link{format_headcount_result}}. See \code{\link{filter_programs_by_opt}} for details on the ID-scope filtering strategy.
 
 **Example:**
 ```r
 \dontrun{
-# Department report headcount (detailed)
-result <- get_headcount(
-  programs = cedar_programs,
-  opt = list(dept = "HIST", major = "History")
-)
+# All programs in a department
+result <- get_headcount(cedar_programs, list(dept = "HIST"))
 
-# SFR headcount (aggregated by term and dept)
+# History majors who also have an Anthropology minor
+result <- get_headcount(cedar_programs, list(major = "History", minor = "Anthropology"))
+
+# SFR aggregation
 result <- get_headcount(
-  programs = cedar_programs,
-  opt = list(),
-  group_by = c("term", "department", "student_level")
+  cedar_programs,
+  opt      = list(),
+  group_by = c("term", "dept_code", "student_level")
 )
 }
 
@@ -1095,6 +1630,22 @@ This is a simplified plotting function that creates a single view. For more deta
 
 ---
 
+### `make_headcount_sparklines()`
+
+*Source: headcount.R*
+
+**Headcount Sparkline for Department Dashboard**
+
+Headcount Sparkline for Department Dashboard  Creates a compact static ggplot showing term-by-term headcount for a department's major and minor programs. Faceted by student level (Undergraduate / Graduate), with separate lines for Majors and Minors. Summer terms are already excluded by \code{get_headcount_series()}. Intended for embedding in the "Explore Your Unit" dashboard summary.
+
+**Parameters:**
+
+- `series` - Data frame returned by \code{get_headcount_series()} in dept-dashboard.R. Columns: term, group, student_level_clean, program_cat, count.
+
+**Returns:** A ggplot object, or NULL if series is NULL/empty.
+
+---
+
 ### `get_headcount_data_for_dept_report()`
 
 *Source: headcount.R*
@@ -1106,295 +1657,314 @@ Count Students by Program (Legacy Function)  Legacy headcount function for backw
 **Parameters:**
 
 - `academic_studies_data` - Academic studies data with original column names
-- `opt` - Options list for filtering (passed to count_heads_by_program). Can include filters for campus, college, etc.
+- `opt` - Options list for filtering (passed to get_headcount). Can include filters for campus, college, etc. If empty, dept_code is used.
 - `programs` - Student program enrollment data in CEDAR format. Required columns: student_id, term, student_level, program_type, program_name. This is typically the academic_studies dataset with CEDAR naming.
-- `d_params` - Department report parameters list with: \itemize{ \item term_start - Start term for filtering \item term_end - End term for filtering \item prog_names - Vector of program names to include \item tables - Existing tables list (will be updated) \item plots - Existing plots list (will be updated) }
+- `dept_code` - Character. Department code for filtering (e.g., "HIST", "MATH").
+- `term_start` - Integer. Starting term code for filtering (e.g., 201980).
+- `term_end` - Integer. Ending term code for filtering (e.g., 202580).
 
-**Returns:** Updated d_params with added tables and plots: \describe{ \item{tables}{ \itemize{ \item hc_progs_under - All undergrad programs \item hc_progs_under_long_majors - Undergrad majors only \item hc_progs_under_long_minors - Undergrad minors only \item hc_progs_grad - All grad programs \item hc_progs_grad_long_majors - Grad majors only \item hc_progs_grad_long_minors - Grad minors only } } \item{plots}{Corresponding plotly plots for each table above} }
+**Returns:** List with structure: list( plots  = list(hc_progs_under_long_majors_plot, hc_progs_under_long_minors_plot, hc_progs_grad_long_majors_plot,   hc_progs_grad_long_minors_plot), tables = list(hc_progs_under, hc_progs_under_long_majors, hc_progs_under_long_minors, hc_progs_grad,  hc_progs_grad_long_majors,  hc_progs_grad_long_minors) )
 
 **Details:**
 
-**CEDAR Data Model Only**  This function requires CEDAR-formatted data and will error if legacy column names are provided. There are no fallbacks - CEDAR naming is mandatory.  Workflow: 1. Validates CEDAR column structure (errors with clear message if missing) 2. Calls get_headcount() to get aggregated headcount data 3. Filters by term range and program names 4. Splits into undergraduate/graduate and major/minor subsets 5. Creates plotly plots for each subset 6. Returns all data and plots via d_params  **Column Mappings (Legacy → CEDAR):** - term_code → term - Student Level → student_level - major_type → program_type - major_name → program_name
+**CEDAR Data Model Only**  This function requires CEDAR-formatted data and will error if legacy column names are provided. There are no fallbacks - CEDAR naming is mandatory.  Workflow: 1. Validates CEDAR column structure (errors with clear message if missing) 2. Calls get_headcount() to get aggregated headcount data 3. Filters by term range 4. Splits into undergraduate/graduate and major/minor subsets 5. Creates plotly plots for each subset 6. Returns plots and tables as a plain list  **Column Mappings (Legacy → CEDAR):** - term_code → term - Student Level → student_level - major_type → program_type - major_name → program_name
 
 ---
 
-## load-funcs
+## health-whatif
 
-### `load_funcs()`
+### `get_health_course_rates()`
 
-*Source: load-funcs.R*
+*Source: health-whatif.R*
 
-**Load All CEDAR R Functions**
+**Build Cross-Sectional Course-Taking Rate Table for Health Programs**
 
-Load All CEDAR R Functions  Loads all R source files for the CEDAR application in the correct dependency order: lists first, then branches (utilities), then cones (analysis functions).
+Build Cross-Sectional Course-Taking Rate Table for Health Programs  Computes two weighted average course-taking rates per (program, course, term_type):  rate            — weighted by the steady-state band distribution (fraction of all enrolled student-term observations at each band). Correct assumption for "what does the existing enrolled population need?"  entry_rate      — weighted by the entry band distribution (credit band at first appearance in the program, averaged across all new entrants in the baseline window). Correct assumption for "what will additional new students need?" — naturally captures the mix of true freshmen, transfer students, and program switchers without a transfer flag.  Both rates use the same per-band course-taking rates; only the band weights differ. Attrition is already implicit in both: rates are computed from students who were actually registered, so students who left simply stopped contributing observations.  No cohort progression is modeled. The assumption is that the historical band distribution of new entrants is stable and representative of future new entrants.
 
 **Parameters:**
 
-- `cedar_base_dir` - Character. The base directory of the CEDAR project. All source paths are constructed relative to this directory.
+- `programs` - Data frame. cedar_programs.
+- `students` - Data frame. cedar_students.
+- `program_names` - Character vector. Program names to include.
+- `n_baseline_terms` - Integer. Historical fall and spring terms to use. Default: 6 (≈ 3 years each).
+- `min_n` - Integer. Minimum student-term observations at a credit band for a band-level rate to be included. Default: 10.
+- `max_term` - Integer or NULL. If set, restrict to terms <= max_term (hindcast mode).
 
-**Returns:** NULL (invisibly). Called for side effect of loading functions.
-
-**Details:**
-
-Loading order: 1. **lists/** - Static data: column mappings, term codes, grade definitions 2. **branches/** - Core utilities: caching, filtering, data loading 3. **cones/** - Analysis functions: headcount, degrees, enrollment, etc.
-
-**Example:**
-```r
-\dontrun{
-# From project root
-load_funcs(getwd())
-
-# From Shiny app
-load_funcs(cedar_base_dir)
-}
-
-```
+**Returns:** Data frame with columns: program_name, subject_course, subject_code, course_title, term_type, rate (steady-state weighted), entry_rate (entry-band weighted), n_students, n_eligible, cohort_size. Attribute "band_rates" contains the per-band detail for modal breakdowns. Attribute "entry_band_dist" contains the entry band distribution per (program, term_type) for audit.
 
 ---
 
-## majors
+### `get_section_size_lookup()`
+
+*Source: health-whatif.R*
+
+**Average Section Enrollment Lookup by Course**
+
+Average Section Enrollment Lookup by Course  For each course, computes the average number of students enrolled per section across recent fall terms. This is used as the denominator when converting "additional students" into "additional sections needed."  We use `enrolled` (actual enrollment) not `capacity` (administrative maximum). Capacity values include outliers like 99999 from crosslisted section shells. Enrolled counts reflect the real operating size of sections.  We exclude crosslist partner sections (crosslist_role == "partner") to avoid double-counting enrollments that are already captured in the primary section.
+
+**Parameters:**
+
+- `sections` - Data frame. cedar_sections.
+- `n_baseline_falls` - Integer. Number of recent fall terms to average over. Default: 3.
+
+**Returns:** Named numeric vector: names are subject_course (e.g. "BIOL 1140"), values are average enrolled per section. Courses with no sections or zero average enrollment are excluded.
+
+---
+
+### `project_health_increase()`
+
+*Source: health-whatif.R*
+
+**Project Course Enrollment Impact of a Health Program Increase**
+
+Project Course Enrollment Impact of a Health Program Increase  Cross-sectional model: for each future semester, the additional demand for a course = sum over programs of (additional_students × weighted_rate). weighted_rate comes from get_health_course_rates() and already captures the steady-state band distribution. No cohort progression is tracked.  ── HOW THE PROJECTION WORKS ─────────────────────────────────────────────────  Each future semester is independent. No cohort tracking, no progression.  delta(course, semester) = sum over programs of: additional_students × effective_rate  where: additional_students = avg_headcount × delta_pct/100 × attrition_scale effective_rate      = entry_rate (credit-band distribution of new program entrants) falls back to steady-state rate when no entry data exists entry_rate          = band-level rates weighted by the historical credit-band distribution at first program appearance — captures the real mix of freshmen, CC transfers, and program-switchers  Every projected semester is independent. The same flat delta appears in every fall and spring across the n_years window. No cohort accumulation.  ─────────────────────────────────────────────────────────────────────────────
+
+**Parameters:**
+
+- `rates` - Data frame. Output of get_health_course_rates().
+- `sizes` - Named numeric vector. Output of get_section_size_lookup().
+- `start_term` - Integer. First fall term (Banner format, e.g. 202680).
+- `delta_pct` - Numeric. Percent increase in new admits (e.g. 10 = 10% more).
+- `n_years` - Integer. Years to project. Default: 4.
+- `goal` - "enrollments" or "graduates". Default: "enrollments".
+- `attrition` - Numeric 0–1. Used only when goal = "graduates". Default: 0.20.
+- `threshold` - Numeric 0–1. Sections fraction flag threshold. Default: 0.85.
+
+**Returns:** List: matrix_long, matrix_wide, assumptions.
+
+---
+
+### `get_premajor_pipeline()`
+
+*Source: health-whatif.R*
+
+**Pre-Major Pipeline Analysis for Health Programs**
+
+Pre-Major Pipeline Analysis for Health Programs  Tracks pre-major vs. declared major headcount per program per fall term. Pre-majors are students enrolled in the university who are working toward admission to a competitive program. They are already taking courses and driving enrollment demand — but their course-taking pattern differs from admitted majors (prereqs vs. clinical/upper-division courses).  A structural break is flagged when a program's pre-major count changes by more than 200% in a single year. This indicates a programmatic change (new pre-major pathway formalized, policy change, data reclassification) rather than gradual growth. Structural breaks make simple linear trend extrapolation unreliable and should be highlighted for planners.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `program_names` - Character vector. Program names to include.
+- `n_trend_falls` - Integer. Number of recent fall terms to include. Default: 7.
+
+**Returns:** Named list: \describe{ \item{`pipeline`}{Wide data frame: program_name, term, year, n_majors, n_premajors, total, pct_premajor. One row per (program, fall term).} \item{`structural_breaks`}{Data frame of (program_name, term, break_year) where pre-major count changed > 200% in one year.} }
+
+---
+
+### `get_health_course_trends()`
+
+*Source: health-whatif.R*
+
+**Trend-Based Health-Student Course Enrollment Forecasting**
+
+Trend-Based Health-Student Course Enrollment Forecasting  For each course taken by selected health programs, fits a linear trend to actual health-student enrollment across recent fall terms and projects forward. This is the foundational "load-bearing course" analysis: which courses are growing in health-student demand, how fast, and how does that compare to section capacity?  Unlike the what-if model (which asks "what happens if we add X% more students?"), this function asks "what does the actual historical data say about where demand is headed?" The two approaches are complementary: the trend shows the baseline trajectory; the what-if shows marginal impact.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `students` - Data frame. cedar_students.
+- `sections` - Data frame. cedar_sections.
+- `program_names` - Character vector. Program names to include.
+- `n_trend_falls` - Integer. Historical fall terms to fit the trend. Default: 7. More = more stable trend; fewer = more recent.
+- `project_falls` - Integer. How many future fall terms to project. Default: 4.
+
+**Returns:** Named list: \describe{ \item{`trends`}{Data frame per course: slope, intercept, R², recent_n, avg_section_size, sections_per_year, and one projected-enrollment column per future fall year. Sorted by slope descending.} \item{`history`}{Long-format data frame: actual health-student enrollment per (subject_course, term). Use for plotting or audit.} \item{`trend_falls`}{Integer vector of fall term codes used for fitting.} \item{`proj_years`}{Integer vector of projected fall years.} }
+
+---
+
+### `get_course_pressure()`
+
+*Source: health-whatif.R*
+
+**Course Capacity Pressure Indicators for Health Program Cohorts**
+
+Course Capacity Pressure Indicators for Health Program Cohorts  Identifies courses at risk of becoming enrollment bottlenecks by combining four independent signals, each detectable from existing data without waitlist records:  1. **Fill rate**: sections running near or at capacity (enrolled/capacity). High fill rate = no slack to absorb demand growth. Rising fill rate = the buffer is shrinking.  2. **Health-student share**: health program students as a fraction of total course enrollment. High share means program growth directly drives course demand — there is no dilution from other majors.  3. **Take rate decline**: the fraction of program students who enroll in the course, compared between early and recent baseline terms. A declining rate at the expected credit band suggests students who need the course are not getting it and may be deferring, substituting, or giving up.  4. **Band drift**: the average credit band at which health students enroll in the course, compared early vs. recent. Rightward drift (students taking it later) is consistent with repeated failed attempts before finally getting a seat.  No single signal is conclusive. The pressure score counts how many flags a course trips simultaneously — 3 or 4 flags indicates a course that likely warrants capacity attention.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `students` - Data frame. cedar_students.
+- `sections` - Data frame. cedar_sections.
+- `program_names` - Character vector. Health program names to include.
+- `n_baseline_terms` - Integer. Fall terms to include. Split evenly into early and recent halves for trend signals. Default: 8.
+- `min_health_n` - Integer. Minimum avg health students per term for a course to appear. Default: 10.
+
+**Returns:** Data frame, one row per course, sorted by n_flags descending. Columns: subject_course, course_title, avg_fill, fill_slope, flag_fill, avg_health_share, avg_health_n, flag_share, rate_early, rate_recent, rate_change_pct, flag_rate_drop, band_early, band_recent, band_drift, flag_band_drift, n_flags.
+
+---
+
+### `get_enrollment_matrix()`
+
+*Source: health-whatif.R*
+
+**Course × Program Enrollment Matrix**
+
+Course × Program Enrollment Matrix  Builds a wide matrix showing the average number of students from each selected program enrolled in each course, over the selected term range. Columns represent (program_name × Major/Pre-Major), sorted by total enrollment descending (most students on left). Rows are courses, sorted by total enrollment descending (busiest courses at top).
+
+**Parameters:**
+
+- `programs` - Data frame. `cedar_programs`.
+- `students` - Data frame. `cedar_students`.
+- `program_names` - Character vector of program names to include.
+- `season` - `"fall"` or `"spring"`.
+- `year_range` - Integer vector of length 2: c(start_year, end_year).
+- `undergrad_only` - Logical. Filter to undergraduate students only.
+- `min_students` - Numeric. Minimum average student count for a course to appear in the matrix. Courses below this threshold are suppressed.
+
+**Returns:** Named list: \describe{ \item{`matrix`}{Wide data frame: subject_course, course_title, one column per (program_name × status) group, row_total.} \item{`col_order`}{Character vector of column names in display order.} \item{`col_totals`}{Data frame with col_name and col_total.} \item{`row_totals`}{Data frame with subject_course and row_total.} \item{`season`, `year_range`, `undergrad_only`, `program_names`, `min_students`, `selected_terms`}{Metadata for audit trail.} }
+
+---
+
+## major-changes
 
 ### `detect_major_changes()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
 **Detect major changes for each student across their academic timeline**
 
+Detect major changes for each student across their academic timeline  Compares each student's primary major term-over-term. A change is recorded when program_name differs from the prior term. Each row in the output represents one change event.
+
 **Parameters:**
 
-- `df` - Data frame (academic_studies) with student program data
-- `major_col` - Character string, column name for primary major (default "Major")
-- `id_col` - Character string, column name for student ID (default "ID")
-- `term_col` - Character string, column name for term code (default "term_code")
-- `credits_col` - Character string, column name for credits attempted (default "Credits Attempted")
+- `programs` - cedar_programs data frame.
+- `cohort` - Optional tibble(student_id, cohort_label). If provided, only students in the cohort are analyzed.
+- `opt` - Options list: \itemize{ \item \code{campus}  — character; filter by student_campus \item \code{college} — character; filter by student_college \item \code{dept}    — character; filter by dept_code }
 
-**Returns:** Data frame with one row per major change event
-
-**Example:**
-```r
-changes <- detect_major_changes(academic_studies)
-changes_filtered <- detect_major_changes(academic_studies, opt = list(college = "Arts and Sciences"))
-```
+**Returns:** Tibble with one row per major change event: student_id, change_term, prev_term, from_major, to_major, unm_credits_before_change, total_credits_before_change (lag-adjusted attempted hours, UNM-only and UNM + transfer), unm_credits_at_change, total_credits_at_change (raw cumulative attempted as recorded at change_term), student_college, student_campus, dept_code, student_level, degree
 
 ---
 
 ### `avg_credits_before_major()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Calculate average credits before entering each major (for first-time major changers)**
+**Average credits at time of arriving in each major (via change)**
 
 **Parameters:**
 
-- `changes_df` - Data frame from detect_major_changes()
-- `min_n` - Minimum number of observations to report (default 5)
+- `changes` - Tibble from detect_major_changes()
+- `opt` - Options list; uses opt$min_n (default 5)
 
-**Returns:** Data frame summarizing avg credits by destination major
+**Returns:** Tibble: to_major, avg_unm_credits, median_unm_credits, avg_total_credits, median_total_credits, n_changes, n_students. Credits are lag-adjusted attempted hours (see detect_major_changes()).
 
 ---
 
 ### `majors_moved_out_of()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Identify most common majors students move OUT OF**
+**Most common majors students leave**
 
 **Parameters:**
 
-- `changes_df` - Data frame from detect_major_changes()
-- `min_n` - Minimum number of observations to report (default 5)
+- `changes` - Tibble from detect_major_changes()
+- `opt` - Options list; uses opt$min_n (default 5)
 
-**Returns:** Data frame of source majors ranked by frequency
+**Returns:** Tibble: from_major, n_exits, ranked by frequency
 
 ---
 
 ### `major_change_pathways()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Identify most common major change pathways (A → B)**
+**Most common A → B major change pathways**
 
 **Parameters:**
 
-- `changes_df` - Data frame from detect_major_changes()
-- `min_n` - Minimum number of observations to report (default 3)
+- `changes` - Tibble from detect_major_changes()
+- `opt` - Options list; uses opt$min_n (default 3)
 
-**Returns:** Data frame of pathways ranked by frequency
+**Returns:** Tibble: from_major, to_major, n_changes, avg_unm_credits, avg_total_credits. Credits are lag-adjusted attempted hours at the move.
 
 ---
 
 ### `pathways_by_college()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Analyze major change pathways by college**
+**Major change pathways broken out by college**
 
 **Parameters:**
 
-- `changes_df` - Data frame from detect_major_changes()
-- `min_n` - Minimum number of observations to report (default 3)
-- `use_translated` - Logical, use Translated College vs Actual College (default TRUE)
+- `changes` - Tibble from detect_major_changes()
+- `opt` - Options list; uses opt$min_n (default 3)
 
-**Returns:** Data frame of pathways by college
+**Returns:** Tibble: student_college, from_major, to_major, n_changes, avg_unm_credits, avg_total_credits (lag-adjusted attempted hours)
 
 ---
 
 ### `time_to_first_change()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Calculate time to first major change (in terms)**
+**Terms from first enrollment to first major change**
+
+Terms from first enrollment to first major change  Uses term_diff() for accurate term counting (summers excluded by default).
 
 **Parameters:**
 
-- `df` - Data frame (academic_studies)
-- `id_col` - Character string, column name for student ID (default "ID")
-- `term_col` - Character string, column name for term code (default "term_code")
-- `major_col` - Character string, column name for major (default "Major")
+- `programs` - cedar_programs data frame
+- `cohort` - Optional tibble(student_id, cohort_label)
+- `opt` - Options list (passed through to detect_major_changes)
 
-**Returns:** Data frame with student_id, first_term, first_change_term, terms_until_change
+**Returns:** Tibble: student_id, first_term, first_change_term, terms_until_change, from_major, to_major
 
 ---
 
 ### `tag_major_changers()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Identify students who changed major vs. those who didn't (cohort tagging)**
+**Tag students by whether they ever changed major**
 
 **Parameters:**
 
-- `df` - Data frame (academic_studies)
-- `id_col` - Character string, column name for student ID (default "ID")
-- `term_col` - Character string, column name for term code (default "term_code")
-- `major_col` - Character string, column name for major (default "Major")
+- `programs` - cedar_programs data frame
+- `cohort` - Optional tibble(student_id, cohort_label)
+- `opt` - Options list (passed through to detect_major_changes)
 
-**Returns:** Data frame with student_id, changed_major (boolean), n_changes, majors_held (comma-separated)
+**Returns:** Tibble: student_id, changed_major, n_changes, n_majors_held, majors_held (comma-separated sequence)
 
 ---
 
-### `major_change_report()`
+### `get_major_change_courses()`
 
-*Source: majors.R*
+*Source: major-changes.R*
 
-**Generate comprehensive major change report**
+**Courses students were enrolled in during the term they changed majors**
+
+Courses students were enrolled in during the term they changed majors  Joins major change events to cedar_students by student_id + change_term. Useful for identifying courses correlated with leaving or arriving in a major.  To analyze departures from a major, filter changes to from_major == X before calling. To analyze arrivals, filter to to_major == X.
 
 **Parameters:**
 
-- `df` - Data frame (academic_studies)
-- `opt` - Optional list of filter parameters (campus, college, dept)
-- `min_n` - Minimum observations for summaries (default 5)
+- `changes` - Tibble from detect_major_changes(). Pre-filter to the from_major or to_major of interest before passing in.
+- `students` - cedar_students data frame
+- `opt` - Options list: \itemize{ \item \code{min_n} — integer; minimum students per course (default 5) }
 
-**Returns:** Named list of analysis results
+**Returns:** Tibble: subject_course, course_title, n_students, pct_of_changers, sorted by n_students descending
 
 ---
 
-## outcomes
+### `get_declaration_context()`
 
-### `get_outcomes()`
+*Source: major-changes.R*
 
-*Source: outcomes.R*
+**Snapshot of credits and prior course history at the moment students first**
 
-**Student Outcomes Analysis**
-
-Student Outcomes Analysis  This function analyzes student outcomes and persistence patterns after course completion. Leverages existing gradebook.R infrastructure for consistent grade processing.
+Snapshot of credits and prior course history at the moment students first declared the focal program
 
 **Parameters:**
 
-- `students` - Data frame containing class list data with enrollment and grade information
-- `opt` - List containing filtering and analysis options
+- `programs` - cedar_programs filtered to population students
+- `students` - cedar_students (full, will be filtered internally)
+- `population` - Population tibble from build_population() — needs first_unm_term for terms-to-declaration calculation
+- `focal_subjects` - Character vector of subject codes that belong to the focal unit (e.g. c("HIST") for a History population). Used to split prior courses into in-unit vs outside.
+- `opt` - Options list; uses opt$min_n (default 5)
 
-**Returns:** List containing outcomes analysis tables and summaries
-
-**Example:**
-```r
-\dontrun{
-opt <- list(courses = c("MATH 1215", "ENGL 1110"))
-outcomes_data <- get_outcomes(students, opt)
-}
-```
-
----
-
-### `analyze_failure_persistence_with_grades()`
-
-*Source: outcomes.R*
-
-**Analyze Failure Persistence with Grade Data**
-
-Analyze Failure Persistence with Grade Data  Uses gradebook infrastructure to track students who fail courses
-
-**Parameters:**
-
-- `students` - Filtered student data
-- `grades_data` - Grade data from get_grades()
-
-**Returns:** Data frame with failure persistence analysis
-
----
-
-### `analyze_dfw_trends()`
-
-*Source: outcomes.R*
-
-**Analyze DFW Trends Over Time**
-
-Analyze DFW Trends Over Time  Uses gradebook course_term data to show DFW trends
-
-**Parameters:**
-
-- `grades_data` - Grade data from get_grades()
-
-**Returns:** Data frame with DFW trends over time
-
----
-
-### `analyze_instructor_outcomes()`
-
-*Source: outcomes.R*
-
-**Analyze Instructor Impact on Outcomes**
-
-Analyze Instructor Impact on Outcomes  Uses gradebook instructor-level data to compare outcomes
-
-**Parameters:**
-
-- `grades_data` - Grade data from get_grades()
-
-**Returns:** Data frame with instructor outcome analysis
-
----
-
-### `analyze_next_term_enrollment_with_grades()`
-
-*Source: outcomes.R*
-
-**Analyze Next Term Enrollment with Grade Categories**
-
-Analyze Next Term Enrollment with Grade Categories  Uses CEDAR's grade categorization for enrollment analysis
-
-**Parameters:**
-
-- `students` - Filtered student data
-
-**Returns:** Data frame with next term enrollment analysis
-
----
-
-### `plot_outcomes_for_course_report()`
-
-*Source: outcomes.R*
-
-**Plot Outcomes for Course Report**
-
-Plot Outcomes for Course Report  Creates visualizations leveraging gradebook infrastructure
-
-**Parameters:**
-
-- `outcomes` - Outcomes list from get_outcomes()
-- `opt` - Options list
-
-**Returns:** Plotly object with outcomes visualization
+**Returns:** Named list: credits (summary tibble), courses_focal, courses_other, n_declarers, focal_subjects
 
 ---
 
@@ -1417,378 +1987,482 @@ process_reports  Main function to process MyReports data files. - Loads configur
 
 ---
 
-## regstats
+## pathway
 
-### `get_high_fall_sophs()`
+### `get_course_timing()`
 
-*Source: regstats.R*
+*Source: pathway.R*
 
-**Identify High-Enrollment Fall Sophomore Courses**
+**Get Course Timing for a Student Population**
 
-Identify High-Enrollment Fall Sophomore Courses  Finds fall courses with high sophomore enrollment (100+ students) that could be considered for summer offerings. This helps with planning summer schedules by identifying courses with strong demand from students who will be juniors in fall.
+Get Course Timing for a Student Population  For each course taken by population students, computes how many students took it in each relative term of their academic career (1st, 2nd, 3rd term enrolled, etc.). Returns a data frame suitable for `plot_curriculum_map()`.  The `cohort` parameter accepts any tibble with `student_id` and `population_label` columns — typically output from `build_population()`. Despite the parameter name, this is a program-based population filter, not an entry-term cohort. Students from all entry years are included and each student's relative term 1 is anchored to their own first enrolled semester.
 
 **Parameters:**
 
-- `students` - Data frame of student enrollments from cedar_students table. Must include columns: campus, college, term, term_type, student_classification, subject_course, course_title, level
-- `courses` - Data frame of course sections (currently unused but kept for consistency)
-- `opt` - Options list (currently unused - function uses hardcoded filters)
+- `students` - Data frame. The `cedar_students` table.
+- `cohort` - Data frame. Output of `build_population()`. Must have columns `student_id` and `population_label`. Defines the student population to analyze.
+- `opt` - List of options: \describe{ \item{`start_classification`}{Character vector. Restrict to students whose first enrollment had this classification. Common values: `"Freshman"` (matches "Freshman, 1st Yr, 1st Sem" and "Freshman, 1st Yr, 2nd Sem"), `"Sophomore"`, `"Junior"`, `"Transfer"`. Partial matching is used. Default: no restriction (all students included).} \item{`include_summer`}{Logical. Whether to count summer as a separate relative term. If `FALSE` (default), summer enrollments are included in the surrounding term's count but summer itself does not advance the relative term counter.} \item{`max_relative_term`}{Integer. Cap on relative terms shown. Default: `8`.} \item{`min_n`}{Integer. Minimum number of population students who must have taken a course (across all terms) for it to appear. Default: `10`.} \item{`subject_code`}{Character vector. Restrict to courses in these subjects (e.g., `c("BIOL", "CHEM")`). Optional.} }
 
-**Returns:** Data frame with single column: \itemize{ \item \code{subject_course} - Course identifiers with 100+ fall sophomores }
-
-**Details:**
-
-The function: \enumerate{ \item Filters for "Sophomore, 2nd Yr" classification \item Filters for fall term only \item Uses \code{rollcall()} to calculate mean enrollment by course \item Returns courses with mean > 100 sophomores }  The 100-student threshold is somewhat arbitrary and could be refined based on institutional capacity for summer offerings.
+**Returns:** Data frame with columns: \describe{ \item{`subject_course`}{Course identifier, e.g., `"BIOL 2310"`.} \item{`subject_code`}{Subject prefix, e.g., `"BIOL"`.} \item{`course_title`}{Course title (most common title for that course).} \item{`relative_term`}{Integer. Relative term number (1 = student's first term enrolled, 2 = second, etc.).} \item{`n_students`}{Number of population students who took this course in this relative term.} \item{`n_eligible`}{Number of population students who reached this relative term (denominator). Students with fewer terms than `relative_term` are excluded so later terms aren't penalized.} \item{`pct_pop`}{`n_students / n_eligible`, rounded to 3 decimal places. Column name retained for downstream compatibility.} \item{`median_term`}{Median relative term in which this course is taken, across all population students who took it. Used for sorting in `plot_curriculum_map()`.} }
 
 **Example:**
 ```r
 \dontrun{
-# Find popular sophomore fall courses
-opt <- list()
-high_soph_courses <- get_high_fall_sophs(cedar_students, cedar_sections, opt)
-
-# These courses could be summer offerings
-print(high_soph_courses$subject_course)
+population <- build_population(cedar_programs,
+                           opt = list(type = "health",
+                                      health_programs = "Radiologic Sciences"))
+timing <- get_course_timing(cedar_students, population, opt = list())
+plot_curriculum_map(timing)
 }
 
 ```
 
 ---
 
-### `get_after_bumps()`
+### `plot_curriculum_map()`
 
-*Source: regstats.R*
+*Source: pathway.R*
 
-**Identify Courses Taken After Enrollment Bumps**
+**Plot Curriculum Map Heatmap**
 
-Identify Courses Taken After Enrollment Bumps  For courses experiencing enrollment bumps (unusually high registration), identifies the top 5 courses that students take next. This helps with capacity planning by anticipating downstream enrollment pressure from bump courses.
+Plot Curriculum Map Heatmap  Visualizes course timing data as a heatmap: relative term on the x-axis, course on the y-axis (sorted by median term taken), and cell fill showing what percentage of eligible cohort students took that course in that term.
 
 **Parameters:**
 
-- `bumps` - Data frame of bump courses (output from get_reg_stats()$bumps). Must include column: subject_course
-- `students` - Data frame of student enrollments from cedar_students table
-- `courses` - Data frame of course sections from cedar_sections table
-- `opt` - Options list passed through to \code{where_to()} for filtering
+- `timing_data` - Data frame. Output of `get_course_timing()`.
+- `opt` - List of options: \describe{ \item{`title`}{Character. Plot title. Default: `"Curriculum Map"`.} \item{`pct_label_threshold`}{Numeric (0-1). Only show percentage labels inside cells above this value. Default: `0.05` (5%).} \item{`fill_color`}{Character. High-end fill color. Default: `"#1a6b8a"` (dark teal). Can be any ggplot2-compatible color string.} \item{`facet_by_subject`}{Logical. If `TRUE`, facet rows by subject code (e.g., all BIOL courses grouped, then CHEM, etc.). Default: `FALSE`.} \item{`top_n`}{Integer. Maximum number of courses to display. Courses are ranked by their peak `pct_pop` across all terms; only the top `top_n` are shown. Default: `40`.} \item{`min_pct`}{Numeric (0–1). Courses where no term exceeds this percentage are dropped before applying `top_n`. Default: `0.05`.} }
 
-**Returns:** Data frame with single column: \itemize{ \item \code{subject_course} - Unique courses frequently taken after bump courses }
-
-**Details:**
-
-For each bump course, the function: \enumerate{ \item Calls \code{where_to()} to find courses students take next \item Ranks by average contribution to those next courses \item Selects top 5 downstream courses \item Aggregates across all bump courses and returns unique list }  This is useful for enrollment forecasting - if MATH 1430 has a bump and students typically take MATH 1440 next, MATH 1440 will likely see increased demand next term.
+**Returns:** A ggplot2 object. Use `ggsave()` to save or display in RStudio viewer.
 
 **Example:**
 ```r
 \dontrun{
-# Get bump courses and their downstream effects
-opt <- list(term = "202510", course_college = "AS")
-flagged <- get_reg_stats(cedar_students, cedar_sections, opt)
-after_bumps <- get_after_bumps(flagged$bumps, cedar_students, cedar_sections, opt)
+timing <- get_course_timing(cedar_students, cohort, opt = list())
+plot_curriculum_map(timing)
 
-# These courses may need capacity increases next term
-print(after_bumps$subject_course)
+# Save to file
+p <- plot_curriculum_map(timing, opt = list(title = "Radiologic Sciences Pathway"))
+ggsave("output/radiology-pathway.png", p, width = 12, height = 8)
+
+# Subject-only view
+plot_curriculum_map(timing %>% filter(subject_code %in% c("BIOL","CHEM","PHYS")))
 }
 
 ```
 
 ---
 
-### `get_reg_stats()`
+### `get_course_pairs()`
 
-*Source: regstats.R*
+*Source: pathway.R*
 
-**Detect Registration Anomalies and Enrollment Concerns**
+**Get Ordered Course Pairs for a Student Population**
 
-Detect Registration Anomalies and Enrollment Concerns  Analyzes historical enrollment patterns to identify courses with unusual registration behavior including bumps (higher than normal), dips (lower than normal), drops (higher early/late withdrawal), squeezes (high enrollment with low capacity), and waitlists. This is the primary tool for identifying enrollment concerns that need administrative attention.
+Get Ordered Course Pairs for a Student Population  Identifies the most common ordered course sequences — cases where a student took course A in one term and course B in a later term. This captures the implicit prerequisite chains that students actually follow, as opposed to the formally catalogued ones.  Only courses taken by at least `opt$min_n` population students are included. Only pairs where the A→B pattern occurred at least `opt$min_pair_n` times are returned.
 
 **Parameters:**
 
-- `students` - Data frame of student enrollments from cedar_students table. Must include columns: campus, college, term, term_type, subject_course, course_title, level, student_id, registration_status
-- `courses` - Data frame of course sections from cedar_sections table. Must include columns: campus, college, term, subject_course, gen_ed_area, enrolled, waiting, avail
-- `opt` - Options list for filtering and thresholds: \itemize{ \item \code{term} - Term code(s) to analyze (e.g., 202510) \item \code{course} - Course identifier(s) to analyze (e.g., "MATH 1430") \item \code{course_college} - College code(s) to filter (e.g., "AS") \item \code{course_campus} - Campus code(s) to filter (e.g., "MAIN") \item \code{level} - Course level(s) to filter (e.g., "undergrad") \item \code{thresholds} - Custom threshold list (see Details) }
+- `students` - Data frame. The `cedar_students` table.
+- `cohort` - Data frame. Output of `build_population()`. Defines the student population to analyze — a program-based filter, not an entry-term cohort.
+- `opt` - List of options: \describe{ \item{`min_n`}{Integer. Minimum population students who took course A for it to be included as a pair source. Default: `15`.} \item{`min_pair_n`}{Integer. Minimum population students exhibiting the A→B pattern for the pair to appear in results. Default: `10`.} \item{`max_term_gap`}{Integer. Maximum number of relative terms between A and B. Default: `4` (pairs more than 4 terms apart are unlikely to be meaningfully sequential).} \item{`subject_code`}{Character vector. Restrict to courses in these subjects. Optional.} \item{`censor_term`}{Integer term code of the last complete data term. When supplied, A-side enrollments (and the `pct_a_to_b` denominator) are restricted to terms with `max_term_gap` complete regular terms of follow-up, so recently-taken courses don't show deflated follow-on rates purely because the data ends (right-censoring). Optional; NULL preserves uncensored behavior.} }
 
-**Returns:** Named list with anomaly data frames and metadata: \itemize{ \item \code{early_drops} - Courses with unusually high early drops \item \code{late_drops} - Courses with unusually high late drops \item \code{dips} - Courses with unusually low enrollment \item \code{bumps} - Courses with unusually high enrollment \item \code{waits} - Courses with significant waitlists \item \code{squeezes} - Courses with low seat availability relative to historical drops \item \code{all_flagged_courses} - Character vector of all flagged course identifiers \item \code{tiered_summary} - Summary of concerns by severity tier \item \code{high_fall_sophs} - Popular fall sophomore courses (non-Shiny only) \item \code{thresholds} - Thresholds used for detection \item \code{cache_info} - Cache metadata including age and parameters }
-
-**Details:**
-
-## Detection Methodology The function uses population standard deviation to identify statistical anomalies: \itemize{ \item \strong{Bumps/Drops:} Flags values >= +1 SD above mean ("high" anomalies) \item \strong{Dips:} Flags values <= -1 SD below mean ("low" anomalies) \item \strong{Concern Tiers:} \itemize{ \item Critical: ±1.5 SD (immediate attention needed) \item Moderate: ±1.0 SD (notable change) \item Marginal: ±0.5 SD (minor change worth monitoring) } }  ## Default Thresholds Default thresholds from \code{cedar_regstats_thresholds}: \itemize{ \item \code{min_impacted} = 20 (minimum student impact for bumps/dips/drops) \item \code{pct_sd} = 1 (minimum standard deviations for flagging) \item \code{min_squeeze} = 0.3 (minimum squeeze ratio: avail/historical_drops) \item \code{min_wait} = 20 (minimum waitlist size) \item \code{section_proximity} = 0.3 (proximity threshold for sections) }  ## Custom Thresholds Custom thresholds can be provided via \code{opt$thresholds}. If custom thresholds differ from defaults, caching is bypassed to ensure fresh calculations.  ## Caching Results are cached for 24 hours when using standard thresholds. Cache files are stored in \code{cedar_data_dir/regstats/} with names based on filtering parameters (college, term, level, campus). Old cache files are automatically cleaned up, keeping only the 20 most recent files.  ## Anomaly Types Explained \itemize{ \item \strong{Early Drops:} High withdrawal before census (dr_early) \item \strong{Late Drops:} High withdrawal after census (dr_late) \item \strong{Dips:} Lower than normal registration (may indicate declining interest) \item \strong{Bumps:} Higher than normal registration (may indicate unmet demand) \item \strong{Waits:} Significant waitlists (definite capacity shortage) \item \strong{Squeezes:} Low seat availability relative to typical drops (calculated as avail/dr_all_mean < threshold) }
+**Returns:** Data frame sorted by `n_students` descending, with columns: \describe{ \item{`course_a`}{First course in the pair.} \item{`course_b`}{Second course (taken after A).} \item{`n_students`}{Population students who took A and then took B.} \item{`n_took_a`}{Total population students who took course A (denominator).} \item{`pct_a_to_b`}{`n_students / n_took_a`: of students who took A, what fraction went on to take B?} \item{`pct_pop_took_b`}{Baseline: share of all analyzed population students who ever took B (any order).} \item{`lift`}{`pct_a_to_b / pct_pop_took_b`. Near 1 = B is simply a popular course; well above 1 = a genuine sequence signal. Approximate: the numerator is order/gap-conditioned, the baseline is not.} \item{`median_term_gap`}{Median number of relative terms between taking A and taking B.} }
 
 **Example:**
 ```r
 \dontrun{
-# Analyze all Arts & Sciences courses for Fall 2025
-opt <- list(term = "202510", course_college = "AS")
-flagged <- get_reg_stats(cedar_students, cedar_sections, opt)
-
-# View courses with enrollment bumps
-head(flagged$bumps)
-
-# Check waitlist concerns
-print(flagged$waits)
-
-# See all flagged courses
-print(flagged$all_flagged_courses)
-
-# View summary by concern tier
-print(flagged$tiered_summary)
-
-# Use custom thresholds (bypasses cache)
-custom_opt <- list(
-  term = "202510",
-  thresholds = list(
-    min_impacted = 30,
-    pct_sd = 1.5,
-    min_wait = 30,
-    min_squeeze = 0.2
-  )
-)
-custom_flagged <- get_reg_stats(cedar_students, cedar_sections, custom_opt)
+population <- build_population(cedar_programs,
+                           opt = list(type = "health",
+                                      health_programs = "Radiologic Sciences"))
+pairs <- get_course_pairs(cedar_students, population, opt = list())
+# Top transitions out of BIOL 2310
+pairs %>% filter(course_a == "BIOL 2310")
 }
 
 ```
 
 ---
 
-### `create_regstat_report()`
+### `get_event_adjacent_courses()`
 
-*Source: regstats.R*
+*Source: pathway.R*
 
-**Generate Registration Statistics Report**
+**Get Courses Adjacent to Student Entry or Exit Events**
 
-Generate Registration Statistics Report  Creates a comprehensive PDF/HTML report of registration anomalies and enrollment concerns by calling \code{get_reg_stats()} and rendering the regstats Rmd template.
+Get Courses Adjacent to Student Entry or Exit Events  Finds courses taken in the term(s) immediately before a population-level change event and compares their frequency across two groups. For entry events: converters (pre-majors who eventually declared) vs. non-converters (pre-majors who left without declaring). For exit events: students who left vs. students who stayed.  Lift > 1 means the course appears disproportionately in the primary group (converters for entry, leavers for exit) relative to the comparison group. This is a correlation, not evidence of causation.
 
 **Parameters:**
 
-- `students` - Data frame of student enrollments from cedar_students table
-- `courses` - Data frame of course sections from cedar_sections table
-- `opt` - Options list passed through to \code{get_reg_stats()} and report rendering: \itemize{ \item \code{term} - Term code(s) to analyze \item \code{course_college} - College code(s) to filter \item \code{arrange} - Optional column name for custom sorting \item Other filtering options (see \code{\link{get_reg_stats}}) }
+- `students` - Data frame. The `cedar_students` table.
+- `population` - Data frame. Output of `build_population()`. Must have columns `student_id`, `outcome`, `first_unit_term`, `last_unit_term`. `entry_status` is not required — groups are assigned by outcome alone, so all entry paths (pre_major, switched_in, undecided) are included.
+- `event` - Character. `"entry"` (default) or `"exit"`.
+- `window` - Integer. Number of non-summer terms to look back from the event term. Default: `1L` (the single term immediately preceding).
+- `include_event_term` - Logical. Whether to include the event term itself. Default: `FALSE`. Setting `TRUE` mixes gateway courses with first-term required courses.
+- `min_n` - Integer. Minimum students per group for a course to appear. Default: `5L`.
 
-**Returns:** NULL (side effect: renders report to output directory)
-
-**Details:**
-
-The function: \enumerate{ \item Calls \code{get_reg_stats()} to detect anomalies \item Optionally sorts results by \code{opt$arrange} column \item Packages data into format expected by Rmd template \item Calls \code{create_report()} to render regstats-report.Rmd \item Saves output to \code{cedar_output_dir/regstats-reports/} }  Report includes: \itemize{ \item Summary of flagged courses by anomaly type \item Detailed tables for bumps, dips, drops, waits, squeezes \item Tiered concern summaries (critical/moderate/marginal) \item Thresholds used for detection }
-
-**Example:**
-```r
-\dontrun{
-# Generate report for Fall 2025 Arts & Sciences
-opt <- list(term = "202510", course_college = "AS")
-create_regstat_report(cedar_students, cedar_sections, opt)
-
-# Report saved to: cedar_output_dir/regstats-reports/output.pdf
-}
-
-```
+**Returns:** Wide data frame with one row per course and columns for each group's student count (`n_students_*`), group size (`n_group_*`), rate (`pct_*`), and `lift`. Attributes include `ep_meta` (list with n per group, n excluded for no prior term). Returns an empty data frame if no qualifying students are found.
 
 ---
 
-## rollcall
+### `assign_relative_terms()`
 
-### `abbreviate_classification()`
+*Source: pathway.R*
 
-*Source: rollcall.R*
+**Assign Relative Term Numbers to Enrollment Records**
 
-**Abbreviate Student Classification Labels**
-
-Abbreviate Student Classification Labels  Converts verbose MyReports classification labels to shorter display labels to prevent layout issues in pie charts and legends.
+Assign Relative Term Numbers to Enrollment Records  For each student, ranks their enrolled terms chronologically (1 = first term, 2 = second, etc.) and adds a `relative_term` column.  UNM term codes are YYYYSS format (e.g., 202510 = Spring 2025, 202560 = Summer, 202580 = Fall). Numeric sort order is chronological order, so no external lookup is needed.  Summer terms (SS = "60") can be excluded from the counter — they don't advance the relative term number but summer courses are still assigned to the relative term of the preceding non-summer term.
 
 **Parameters:**
 
-- `classification` - Character vector of student classification values
+- `enrolled` - Data frame with columns: `student_id`, `term`.
+- `include_summer` - Logical. Whether summer counts as its own relative term. Default: `FALSE`.
 
-**Returns:** Character vector with abbreviated labels
-
-**Example:**
-```r
-abbreviate_classification("Freshman, 1st Yr, 1st Sem")  # Returns "Freshman"
-abbreviate_classification("Junior, 3rd Yr.")  # Returns "Junior"
-```
+**Returns:** `enrolled` with a `relative_term` integer column added.
 
 ---
 
-### `summarize_student_demographics()`
+## pathways
 
-*Source: rollcall.R*
+### `pathways_level_filter()`
 
-**Summarize Student Demographics**
+*Source: pathways.R*
 
-Summarize Student Demographics  Flexible demographic summary function that groups students by any specified columns (majors, classifications, or other demographic fields) and calculates enrollment counts, means across terms, and percentages of course enrollment. This provides insight into "who" is taking courses over time.
+**Translate Pathways course-level UI choice to CEDAR level values**
 
 **Parameters:**
 
-- `filtered_students` - Data frame of student enrollments from cedar_students table, already filtered by desired criteria. Must include: student_id, term, campus, college, subject_course, and any demographic columns used in grouping.
-- `opt` - Options list containing: \itemize{ \item \code{group_cols} - Character vector of column names to group by. If NULL, uses default: campus, college, term, term_type, major, student_classification, subject_course, course_title, level }
+- `level_choice` - Character scalar from a Pathways level selector.
 
-**Returns:** Data frame with student demographic breakdown including: \describe{ \item{count}{Number of distinct students in this group for THIS SPECIFIC TERM} \item{mean}{Average count across all terms OF THE SAME TERM_TYPE (e.g., avg across all falls). This is the key value used for plotting "average students per term type".} \item{registered}{Total course enrollment for this specific term} \item{registered_mean}{Average course enrollment across terms of same term_type} \item{term_pct}{Percentage of course enrollment this group represents IN THIS TERM (count / registered * 100)} \item{term_type_pct}{AVERAGE percentage across all terms of this term_type (mean / registered_mean * 100). This is what the pie charts display.} } Plus all columns specified in group_cols.  The \code{mean} and \code{term_type_pct} columns answer: "On average, what percentage of students in HIST 1105 are freshmen in fall semesters?" This averages across Fall 2022, Fall 2023, Fall 2024, etc. to give a stable "typical" value.
-
-**Details:**
-
-The function performs the following steps: \enumerate{ \item Groups students by specified columns and counts distinct student_ids \item Removes term from grouping and calculates mean counts across terms \item Calls \code{calc_cl_enrls()} to get total course enrollment counts \item Merges demographic counts with enrollment totals \item Calculates percentages: what % of course enrollment does each group represent \item Sorts by campus, college, term, course, and descending percentage }  This function is useful for answering questions like: \itemize{ \item "What majors are taking MATH 1430?" \item "Are freshmen or seniors more represented in this course?" \item "How has the major composition of BIOL 1110 changed over time?" \item "What percentage of course enrollment comes from each college?" }
-
-**Example:**
-```r
-\dontrun{
-# Summarize by major
-opt <- list(
-  course = "MATH 1430",
-  group_cols = c("campus", "college", "term", "major", "subject_course")
-)
-filtered <- filter_class_list(cedar_students, opt)
-major_summary <- summarize_student_demographics(filtered, opt)
-
-# Summarize by classification
-opt$group_cols <- c("campus", "term", "student_classification", "subject_course")
-class_summary <- summarize_student_demographics(filtered, opt)
-}
-
-```
+**Returns:** Character vector for opt$level, or NULL for all levels.
 
 ---
 
-### `create_rollcall_color_palette()`
+### `pathways_observation_boundary()`
 
-*Source: rollcall.R*
+*Source: pathways.R*
 
-**Create Consistent Color Palette for Rollcall Plots**
+**Latest term whose outcomes are fully observable**
 
-Create Consistent Color Palette for Rollcall Plots  Generates a consistent color mapping for categories across multiple plots to ensure the same majors/classifications have the same colors in fall, spring, and summer plots.
+Latest term whose outcomes are fully observable  Right-censoring guard shared by the Pathways analyses: an outcome measured by "what happened in later terms" (returned next term, later took course B, later entered the major) is only observable for records with enough complete regular terms after them. Records after this boundary would all look like non-returns / non-entries simply because the data ends.
 
 **Parameters:**
 
-- `rollcall_data` - A dataframe containing rollcall data across all term types.
-- `fill_column` - The column name to use for color mapping (e.g., "Student Classification" or "Major")
-- `top_n` - Number of top categories to include in color palette (default: 10)
+- `latest_complete_term` - Integer term code of the last complete data term (typically `subtract_term(cedar_current_term)`).
+- `follow_up_terms` - Integer. How many complete regular (fall/spring) terms of follow-up the analysis needs. 1 for next-term outcomes (stop-out), the A-to-B gap for course pairs, etc.
 
-**Returns:** A named vector of colors where names are category values
-
-**Example:**
-```r
-color_palette <- create_rollcall_color_palette(rollcall_data, "Major", top_n = 8)
-```
+**Returns:** Integer term code: the latest term with full follow-up. NULL if latest_complete_term is NULL/NA.
 
 ---
 
-### `plot_rollcall_summary()`
+### `apply_pathways_population_window()`
 
-*Source: rollcall.R*
+*Source: pathways.R*
 
-**are calculated against total average enrollment (not just top 5).**
+**Apply Pathways analysis term and population membership window**
 
 **Parameters:**
 
-- `rollcall_data` - Data frame from \code{summarize_student_demographics()}. Must contain columns: fill_column, term_type, mean, term_type_pct, campus, college, subject_course
-- `fill_column` - Column name to group by (e.g., "student_classification" or "major")
-- `color_palette` - Named vector of colors from \code{create_rollcall_color_palette()}
-- `filter_column` - Optional list with \code{column} and \code{values} for filtering (e.g., \code{list(column = "campus", values = c("ABQ"))})
+- `data` - Data frame with student_id and term columns.
+- `population` - Population data frame from build_population().
+- `analysis_through` - Optional maximum term to include.
+- `term_col` - Name of the term column in data.
 
-**Returns:** Named list of plotly donut charts: \itemize{ \item \code{fall} - Chart for fall terms (NULL if no data) \item \code{spring} - Chart for spring terms (NULL if no data) \item \code{summer} - Chart for summer terms (NULL if no data) \item \code{by_term} - List of all charts keyed by term_type }
-
-**Example:**
-```r
-\dontrun{
-# Get rollcall data with pre-calculated averages
-rollcall_data <- summarize_student_demographics(filtered_students, opt)
-
-# Create consistent color palette
-color_palette <- create_rollcall_color_palette(rollcall_data, "major")
-
-# Generate plots
-plots <- plot_rollcall_summary(rollcall_data, "major", color_palette)
-plots$fall   # Fall term chart
-plots$spring # Spring term chart
-}
-
-```
+**Returns:** data filtered to analysis_through and relevant_until.
 
 ---
 
-### `rollcall()`
+### `filter_pathways_analysis_population()`
 
-*Source: rollcall.R*
+*Source: pathways.R*
 
-**Rollcall: Student Demographics Over Time**
-
-Rollcall: Student Demographics Over Time  Main rollcall function that analyzes student demographics (majors, classifications, etc.) in courses over time. Filters students by specified criteria, removes historical data before Fall 2019, and creates demographic summaries with enrollment percentages.
+**Apply Pathways analysis population subgroup filters**
 
 **Parameters:**
 
-- `students` - Data frame of student enrollments from cedar_students table. Must include: student_id, term, campus, college, subject_course, registration_status_code, and any demographic columns for grouping.
-- `opt` - Options list for filtering and grouping: \itemize{ \item \code{group_cols} - Character vector of columns to group by. If NULL, uses defaults: campus, college, term, term_type, student_classification, major, subject_course, course_title, level \item \code{reg_status_code} - Registration status codes to include (default: c("RE", "RS")) \item \code{term} - Term code(s) to filter by \item \code{course} - Course identifier(s) to filter by \item Other filtering options supported by \code{filter_class_list()} }
+- `population` - Population data frame from build_population().
+- `split_by` - Population split mode; "entry" excludes unclear entry rows.
+- `selected_label` - Optional population_label selected in the status bar.
 
-**Returns:** Data frame with student demographic breakdown including counts, means, and percentages. See \code{\link{summarize_student_demographics}} for details.
-
-**Details:**
-
-The function performs the following steps: \enumerate{ \item Sets default group_cols if not provided \item Sets default reg_status_code (registered students only) \item Filters students using \code{filter_class_list()} \item Removes data from before Fall 2019 (term < 201980) \item Calls \code{summarize_student_demographics()} to aggregate \item Returns demographic summary with percentages }  Use this function to answer questions like: \itemize{ \item "What majors are taking MATH 1430 and how has that changed?" \item "Are we seeing more upperclassmen in intro courses over time?" \item "Which colleges' students are enrolled in this gen ed course?" }
-
-**Example:**
-```r
-\dontrun{
-# Analyze major composition of a course over time
-opt <- list(
-  course = "BIOL 2305",
-  group_cols = c("campus", "term", "term_type", "major", "subject_course")
-)
-major_breakdown <- rollcall(cedar_students, opt)
-
-# Analyze classification changes across all MATH courses
-opt <- list(
-  subject = "MATH",
-  group_cols = c("campus", "term", "student_classification", "subject_course")
-)
-class_breakdown <- rollcall(cedar_students, opt)
-}
-
-```
+**Returns:** Filtered population.
 
 ---
 
-### `plot_time_series()`
+### `resolve_pathways_focal_programs()`
 
-*Source: rollcall.R*
+*Source: pathways.R*
 
-**Plot Classification Time Series**
-
-Plot Classification Time Series  Creates line plots showing the percentage of students in each classification across terms over time.
+**Resolve focal program names for a Pathways population option**
 
 **Parameters:**
 
-- `rollcall_data` - A dataframe from summarize_student_demographics containing rollcall data with term info.
-- `value_column` - The column to use for y-axis values (default: "term_pct")
-- `top_n` - Number of top classifications/majors to display (default: 8)
+- `population_opt` - Option list used to build the population.
+- `programs` - cedar_programs.
+- `pop_programs` - Optional cedar_programs already filtered to population IDs.
 
-**Returns:** A plotly object showing time series lines.
-
-**Example:**
-```r
-plot_time_series(rollcall_data, fill_column = "student_classification", value_column = "term_type_pct", top_n = 6)
-```
+**Returns:** Character vector of program names.
 
 ---
 
-### `plot_rollcall_with_consistent_colors()`
+### `resolve_pathways_focal_dept_codes()`
 
-*Source: rollcall.R*
+*Source: pathways.R*
 
-**Plot Rollcall Summary with Consistent Colors Across Terms**
-
-Plot Rollcall Summary with Consistent Colors Across Terms  Wrapper function that creates rollcall plots with consistent color mapping across all term types (fall, spring, summer).
+**Resolve focal department codes for a Pathways population option**
 
 **Parameters:**
 
-- `rollcall_data` - A dataframe containing rollcall data for all terms.
-- `fill_column` - The column name to use for fill aesthetic.
-- `top_n` - Number of top categories to include (default: 7)
-- `filter_column` - Optional list with column name and values to filter data (e.g., list(column = "campus", values = c("ABQ", "TAOS")))
+- `population_opt` - Option list used to build the population.
+- `programs` - cedar_programs.
+- `pop_programs` - Optional cedar_programs already filtered to population IDs.
 
-**Returns:** A list of plots with consistent colors across term types.
+**Returns:** Character vector of dept_code values.
 
-**Example:**
-```r
-consistent_plots <- plot_rollcall_with_consistent_colors(rollcall_data, "major", top_n = 8)
-# With campus filter:
-campus_filter <- list(column = "campus", values = c("ABQ"))
-filtered_plots <- plot_rollcall_with_consistent_colors(rollcall_data, "major", 7, campus_filter)
-```
+---
+
+### `resolve_pathways_focal_subjects()`
+
+*Source: pathways.R*
+
+**Resolve focal course subject prefixes for Pathways analyses**
+
+**Parameters:**
+
+- `population_opt` - Option list used to build the population.
+- `programs` - cedar_programs.
+- `lookups` - cedar_lookups list; must include subject_lookup.
+- `pop_programs` - Optional cedar_programs already filtered to population IDs.
+
+**Returns:** Character vector of subject_code values.
+
+---
+
+### `resolve_pathways_gen_ed_courses()`
+
+*Source: pathways.R*
+
+**Resolve department gen ed courses from focal subject prefixes**
+
+**Parameters:**
+
+- `focal_subjects` - Character vector of subject prefixes.
+- `gen_ed_courses` - Character vector of gen ed subject_course codes.
+
+**Returns:** Character vector of gen ed subject_course values.
+
+---
+
+## population-trend
+
+### `make_population_trend()`
+
+*Source: population-trend.R*
+
+**Plot student population mix over time for a department's majors**
+
+**Parameters:**
+
+- `programs` - cedar_programs data frame (must include student_population).
+- `dept_code` - Department code (e.g., "HIST", "GES").
+- `program_type` - Which program type to include. Default "Major" (primary majors only). Pass NULL to include all types (majors + minors + concentrations).
+- `student_level` - Filter to "Undergraduate" (default) or NULL for all levels.
+
+**Returns:** A ggplot proportional stacked bar chart.
+
+---
+
+## population
+
+### `get_ongoing_ids()`
+
+*Source: population.R*
+
+**Get Ongoing Student IDs**
+
+Get Ongoing Student IDs  Returns all students currently engaged with a focal program in the most recent data term. Includes two groups: - Declared focal students whose last program record is max_data_term - Pre-major-only students whose focal pre-major record is max_data_term (these students haven't had a chance to declare yet)
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `focal_names` - Character vector. Focal program names.
+- `max_data_term` - Integer. The most recent term in the data.
+
+**Returns:** Character vector of student IDs.
+
+---
+
+### `get_graduated_ids()`
+
+*Source: population.R*
+
+**Get Graduated Student IDs**
+
+Get Graduated Student IDs  Returns students who received a focal-program degree within the graduation window: [last_declared_term, last_declared_term + 100]. The +100 window covers the typical 1–2 term lag between a student's last program record and when their degree is formally conferred.  Only counts graduation_status values that represent a real outcome: "Awarded", "Pending", "Sought". Excludes "Hold Pending" (admin block) and "Record Clear" (application withdrawn).
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `degrees` - Data frame or NULL. cedar_degrees. Returns empty vector if NULL.
+- `focal_names` - Character vector. Focal program names.
+- `focal_codes` - Character vector. Focal program codes (optional). When supplied and the degrees table has a major_code column, restricts matches to degrees in those codes.
+
+**Returns:** Character vector of student IDs.
+
+---
+
+### `get_switched_out_ids()`
+
+*Source: population.R*
+
+**Get Switched-Out Student IDs (detection only)**
+
+Get Switched-Out Student IDs (detection only)  Returns students who have a declared non-focal program record at any term strictly after their last declared focal term. This is a detection function — priority over other outcomes (ongoing, graduated) is applied by the orchestrator, not here.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `focal_names` - Character vector. Focal program names.
+
+**Returns:** Character vector of student IDs.
+
+---
+
+### `get_never_declared_ids()`
+
+*Source: population.R*
+
+**Get Never-Declared Student IDs**
+
+Get Never-Declared Student IDs  Returns students who appeared only as a pre-major in the focal program — never declared — and whose last focal pre-major record predates max_data_term. Students with a pre-major record IN max_data_term are classified as ongoing (current pre-majors), not never_declared.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `focal_names` - Character vector. Focal program names.
+- `max_data_term` - Integer. The most recent term in the data.
+
+**Returns:** Character vector of student IDs.
+
+---
+
+### `get_entry_pathways()`
+
+*Source: population.R*
+
+**Get Entry Pathways for Declared Focal Students**
+
+Get Entry Pathways for Declared Focal Students  Returns a data frame of student_id + entry_pathway for every student who ever declared the focal program. Pre-major-only students are excluded.  Pathway rules (applied in priority order): pre_major   — had a focal pre-major record strictly before first declaration switched_in — had a non-focal declared major strictly before first declaration direct      — everything else (first UNM major was the focal program)  Note: never_declared is NOT an entry_pathway returned by this function — it is assigned by build_population() to historical pre-major-only students.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `focal_names` - Character vector. Focal program names.
+
+**Returns:** Data frame with columns student_id (chr) and entry_pathway (chr).
+
+---
+
+### `classify_origin()`
+
+*Source: population.R*
+
+**Classify Student UNM Origin**
+
+Classify Student UNM Origin  Returns "transfer", "unm", or "unknown" for each student based on the student_population field in cedar_programs. Uses the student's earliest term across ALL programs — not just focal — so a student who enrolled at UNM as a transfer before declaring the focal program is correctly classified.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs (all programs, not just focal).
+- `candidate_ids` - Character vector. Student IDs to classify.
+
+**Returns:** Data frame with columns student_id (chr) and origin (chr).
+
+---
+
+### `classify_entry_method()`
+
+*Source: population.R*
+
+**Classify How a Student First Arrived at the Focal Unit**
+
+Classify How a Student First Arrived at the Focal Unit  Returns one of three values for each student: first_program — no prior program record of any kind (declared or pre-major, in any unit) before their first focal record. This is their first academic program affiliation. switched_in   — had at least one prior program record somewhere before arriving at the focal unit. unclear       — their first focal record coincides with the earliest term in the full programs table, so prior history is unobservable.  The unclear flag applies only to students who appear "direct" — if a student already has positive evidence of a prior program (switched_in) or a focal pre-major record, that evidence stands regardless of the data boundary.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs (all programs, not just focal).
+- `focal_names` - Character vector. Focal program names.
+- `min_data_term` - Integer. Earliest term in the full programs table.
+
+**Returns:** Data frame with columns student_id (chr) and entry_method (chr).
+
+---
+
+### `classify_entry_status()`
+
+*Source: population.R*
+
+**Classify Whether a Student First Engaged as a Pre-Major or Declared Major**
+
+Classify Whether a Student First Engaged as a Pre-Major or Declared Major  Returns "pre_major" if the student's first focal program record was a pre-major record, "major" if it was a declared major. Purely about their first record — does not consider later declarations.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs (all programs, not just focal).
+- `focal_names` - Character vector. Focal program names.
+
+**Returns:** Data frame with columns student_id (chr) and entry_status (chr).
+
+---
+
+### `build_population()`
+
+*Source: population.R*
+
+**Build a Student Population**
+
+Build a Student Population  Constructs a population data frame from cedar_programs using the outcome-oriented pipeline. Returns one row per student with: student_id, population_label, outcome, origin (unm/transfer/unknown), entry_method (first_program/switched_in/unclear), entry_status (pre_major/major), first_unm_term, first_unit_term, last_unit_term, last_declared_term, last_record_term, relevant_until
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `degrees` - Data frame or NULL. cedar_degrees.
+- `students` - Data frame or NULL. cedar_students (reserved for future use).
+- `opt` - List of options: type          — "preset", "dept", or "major". Default "preset". program_names — required for preset/major types. dept_code     — required for dept type. outcomes      — character vector of outcomes to include. Default: all six outcomes (graduated, switched_out, stopped_out, ongoing, chose_elsewhere, left_undeclared). split_by      — "none" (default), "outcome", "entry", "entry_status", or "transfer". When "entry", population_label is set to entry_method per student. When "entry_status", population_label is set to whether the student first appeared as a declared major or pre-major. When "transfer", population_label is set to origin per student. campus        — character vector. Filter by student_campus. Optional. student_level — character vector. Filter by student_level before outcome detection. Common values: "Undergraduate", "Graduate". When omitted, all levels are included and undergrad/grad students are mixed in a single population. Pass "Undergraduate" to build a clean undergrad cohort for a department that also has grad programs.
+
+**Returns:** Data frame with one row per student.
+
+---
+
+### `get_focal_programs()`
+
+*Source: population.R*
+
+**Get Focal Program Names for a Population Build**
+
+Get Focal Program Names for a Population Build  Resolves focal program names from opt depending on type. Returns a data frame of distinct program_name + major_code values that are in scope.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `opt` - List of options (type, program_names, dept_code).
+
+**Returns:** Data frame with columns program_name and major_code.
+
+---
+
+### `build_demographic_population()`
+
+*Source: population.R*
+
+**Build a Demographic Population**
+
+Build a Demographic Population  Identifies students based on demographic indicators stored in cedar_programs. Membership is resolved as "ever" — a student qualifies if they had the indicator in ANY term, not just the most recent.
+
+**Parameters:**
+
+- `programs` - Data frame. cedar_programs.
+- `opt` - Options list: pell_eligible, first_gen, time_status, ipeds_race, gender, campus, term.
+
+**Returns:** tibble with student_id, population_label, and stub columns outcome = NA, origin/entry_method/entry_status = NA, relevant_until = NA.
 
 ---
 
@@ -2014,10 +2688,10 @@ Get SFR Data for Department Reports  Generates student-faculty ratio plots and d
 
 **Parameters:**
 
-- `data_objects` - Named list containing academic_studies and cedar_faculty data
-- `d_params` - Department report parameters list with: \itemize{ \item \code{dept_code} - Department code (e.g., "HIST", "MATH") \item \code{plots} - Existing plots list (will be updated) }
+- `data_objects` - Named list containing cedar_programs and cedar_faculty data.
+- `dept_code` - Character. Department code (e.g., "HIST", "MATH").
 
-**Returns:** Updated d_params list with added plots: \itemize{ \item \code{ug_sfr_plot} - Undergraduate SFR bar chart by term and major type \item \code{grad_sfr_plot} - Graduate SFR bar chart by term and major type \item \code{sfr_scatterplot} - Department in college context (all terms, majors only) } If insufficient data, plots will contain error messages instead of ggplot objects.
+**Returns:** List with structure: list( plots  = list(ug_sfr_plot, grad_sfr_plot, sfr_scatterplot), tables = list() ) If insufficient data, plot values will be character strings instead of ggplot objects.
 
 **Details:**
 
@@ -2031,20 +2705,165 @@ data_objects <- list(
   academic_studies = academic_studies_data,
   cedar_faculty = cedar_faculty
 )
-d_params <- list(dept_code = "HIST", plots = list())
-d_params <- get_sfr_data_for_dept_report(data_objects, d_params)
-
-# Access plots
-print(d_params$plots$ug_sfr_plot)
-print(d_params$plots$grad_sfr_plot)
-print(d_params$plots$sfr_scatterplot)
+result <- get_sfr_data_for_dept_report(data_objects, "HIST")
+print(result$plots$ug_sfr_plot)
+print(result$plots$grad_sfr_plot)
+print(result$plots$sfr_scatterplot)
 }
 
 ```
 
 ---
 
+## stopout
+
+### `get_stopout()`
+
+*Source: stopout.R*
+
+**Get Stop-Out Analysis for a Cohort**
+
+Get Stop-Out Analysis for a Cohort  For each course taken by cohort students, computes how often a DFW grade leads to not enrolling the following term — and compares that rate to baseline students in the same course.
+
+**Parameters:**
+
+- `students` - Data frame. The `cedar_students` table. Should cover multiple terms so next-term enrollment can be checked.
+- `cohort` - Data frame. Output of `build_population()`. Must have columns `student_id` and `population_label`.
+- `opt` - List of options: \describe{ \item{`term`}{Integer or character vector. Restrict which course-terms to analyze. Optional; defaults to all terms.} \item{`campus`}{Character vector. Restrict to these campus codes. Optional.} \item{`min_n`}{Integer. Minimum number of cohort students with a graded record in a course for it to appear in results. Default: `15`.} }
+
+**Returns:** Named list: \describe{ \item{`by_course`}{Data frame, one row per course, sorted by `cohort_dfw_stopout_rate` descending. Columns: \itemize{ \item `subject_course` — course identifier \item `cohort_n_dfw`, `cohort_n_pass` — cohort student counts by outcome \item `cohort_dfw_stopout_rate` — proportion of DFW cohort students who did not return the next term \item `cohort_pass_stopout_rate` — same for passing cohort students \item `cohort_stopout_gap` — difference (DFW rate minus pass rate); higher = greater penalty for failing \item `cohort_p_value` — chi-squared p-value comparing DFW vs pass stop-out within the cohort \item `baseline_n_dfw`, `baseline_n_pass` — same counts for non-cohort students \item `baseline_dfw_stopout_rate`, `baseline_pass_stopout_rate`, `baseline_stopout_gap`, `baseline_p_value` — same metrics for baseline }} \item{`population_size`}{Integer. Number of unique student IDs in the cohort.} }
+
+**Example:**
+```r
+\dontrun{
+cedar_programs <- qs_read("data/cedar_programs.qs")
+cedar_students <- qs_read("data/cedar_students.qs")
+
+cohort <- build_population(cedar_programs, opt = list(type = "health"))
+result <- get_stopout(cedar_students, cohort, opt = list())
+result$by_course
+
+# Top courses where cohort students stop out after DFW significantly more
+# than baseline students do
+result$by_course %>%
+  filter(cohort_p_value < 0.05) %>%
+  arrange(desc(cohort_stopout_gap - baseline_stopout_gap))
+}
+
+```
+
+---
+
+### `get_dfw_rates()`
+
+*Source: stopout.R*
+
+**Get DFW Rates by Course for a Population**
+
+Get DFW Rates by Course for a Population  For each course taken by population students, computes the DFW rate among population students and the baseline (all other students in the same courses). Sorted by population DFW rate descending.  Shares `classify_outcomes()` with `get_stopout()`. Does not require a next-term lookup, so it is faster and has no edge-case around the most recent term.
+
+**Parameters:**
+
+- `students` - Data frame. The `cedar_students` table.
+- `population` - Data frame. Output of `build_population()`. Must have `student_id`.
+- `opt` - List of options: \describe{ \item{`level`}{Character vector. Course levels to include. Optional.} \item{`campus`}{Character vector. Campus codes to include. Optional.} \item{`min_n`}{Integer. Min population students graded in a course. Default: `10`.} \item{`min_dfw_n`}{Integer. Min population DFW students. Default: `5`.} }
+
+**Returns:** Data frame with one row per course, columns: `subject_course`, `pop_n_graded`, `pop_n_dfw`, `pop_dfw_rate`, `baseline_n_graded`, `baseline_n_dfw`, `baseline_dfw_rate`.
+
+---
+
+### `classify_outcomes()`
+
+*Source: stopout.R*
+
+**Classify Student Enrollment Records as Pass or DFW**
+
+Classify Student Enrollment Records as Pass or DFW  Takes enrollment records and labels each as `"pass"` or `"dfw"` using the canonical CEDAR classification (`classify_enrollment_outcomes()` in trunk/utils.R — see the "CEDAR-wide DFW policy" note in AGENTS.md). Ungraded records (incomplete, audit, no record) are dropped — they provide no signal for stop-out analysis.  DFW covers D/F/W final grades plus late drops (`STATUS_DROP_LATE`). Early drops (`STATUS_DROP_EARLY`) are excluded entirely: a drop before the deadline posts no grade and is not an academic outcome.
+
+**Parameters:**
+
+- `students` - Data frame. The `cedar_students` table.
+
+**Returns:** Data frame with columns: `student_id`, `term`, `subject_course`, `outcome` (`"pass"` or `"dfw"`).
+
+---
+
+### `build_next_term_lookup()`
+
+*Source: stopout.R*
+
+**Build a Next-Term Enrollment Lookup**
+
+Build a Next-Term Enrollment Lookup  For each student-term pair present in the data, determines the next regular academic term and whether the student enrolled in it. Uses `add_next_term_col()` from `utils.R`.  Summer terms are excluded from the "next term" mapping — a student who doesn't enroll in summer is not considered a stop-out.
+
+**Parameters:**
+
+- `students` - Data frame. The full `cedar_students` table (not pre-filtered by term — we need the full enrollment history to check the next term).
+
+**Returns:** Data frame with columns: `student_id`, `term`, `returned_next_term` (logical: `TRUE` if the student had any enrollment the following term).
+
+---
+
+### `compute_stopout_for_group()`
+
+*Source: stopout.R*
+
+**Compute Stop-Out Rates for One Group in One Course**
+
+Compute Stop-Out Rates for One Group in One Course  Given the graded records for a single group (cohort or baseline) in a single course, computes stop-out rates for DFW and passing students, and runs a chi-squared test to assess whether the difference is significant.
+
+**Parameters:**
+
+- `course_group` - Data frame. Rows from `classify_outcomes()` for one group (cohort or baseline) in one course. Must have columns: `student_id`, `term`, `outcome`, and `stopped_out` (pre-joined by caller).
+- `prefix` - Character. Column name prefix for the returned values (`"cohort"` or `"baseline"`).
+
+**Returns:** Single-row tibble with columns: `{prefix}_n_dfw`, `{prefix}_n_pass`, `{prefix}_dfw_stopout_rate`, `{prefix}_pass_stopout_rate`, `{prefix}_stopout_gap`, `{prefix}_p_value`
+
+---
+
 ## transform-to-cedar
+
+### `generate_program_map()`
+
+*Source: transform-to-cedar.R*
+
+**Build program_map from academic_studies**
+
+Build program_map from academic_studies  Parses Banner program codes from raw academic_studies data and resolves each to college_code, dept_code, degree_level, program_type, and canonical_code. Called by transform_to_cedar() when program_map.qs is absent.
+
+**Parameters:**
+
+- `as_file` - Path to academic_studies file (qs or Rds)
+- `ext` - File extension: ".qs" or ".Rds"
+- `subj_dept_map` - Data frame from subj_dept_map.R
+- `premaj_canon` - Named character vector from program_code_maps.R
+- `xvar_explicit` - Named character vector from program_code_maps.R
+- `extra_p2d` - Named character vector from program_code_maps.R
+- `known_suffixes` - Character vector of valid college suffixes
+- `real_F_progs` - Character vector of F-prefix codes that are not pre-majors
+- `get_lev` - Function that maps degree description → degree level string
+
+**Returns:** A tibble with columns: program_code, college_code, dept_code, major_code, degree_abbr, degree_level, program_type, canonical_code
+
+---
+
+### `transform_applicants()`
+
+*Source: transform-to-cedar.R*
+
+**Transforms admissions applicant data to the CEDAR model.**
+
+Transforms admissions applicant data to the CEDAR model. Encrypts student ID, derives term, and renames all columns to snake_case. All non-PII columns from the source report are preserved as-is.
+
+**Parameters:**
+
+- `applicants` - Raw admissions_applicants data frame (output of parse-data.R)
+- `data_dir` - Path to data directory
+- `ext` - File extension
+
+**Returns:** list(saved = list(applicants = <meta>))
+
+---
 
 ### `transform_to_cedar()`
 
@@ -2052,33 +2871,15 @@ print(d_params$plots$sfr_scatterplot)
 
 **Transform MyReports data to CEDAR model**
 
-Transform MyReports data to CEDAR model  Reads existing parsed data files (DESRs, class_lists, etc.) and creates new CEDAR model files (cedar_sections, cedar_students, etc.)  This script is designed to run daily after parse-data.R completes. It will OVERWRITE existing cedar_* files with the latest data.
+Transform MyReports data to CEDAR model  Loads parsed source files, calls each transform function, and saves cedar_* files. Runs daily after parse-data.R. Overwrites existing cedar_* files.
 
 **Parameters:**
 
 - `data_dir` - Path to data directory (default: from config)
 - `use_qs` - Use .qs format (default: from config)
+- `tables` - Character vector of tables to run (default: all) Options: "sections", "students", "programs", "degrees", "faculty", "applicants", "lookups"
 
-**Returns:** List of CEDAR data objects
-
----
-
-## utils
-
-### `add_acad_year()`
-
-*Source: utils.R*
-
-**Add academic year column based on term codes**
-
-Add academic year column based on term codes  This function takes a data frame and a column containing term codes (e.g., "202380" for Fall 2023) and adds a new column `acad_year` representing the academic year (e.g., "2023-2024"). The academic year is determined by the semester code: - "80" (fall): academic year starts with the term year - "10" (spring) and "60" (summer): academic year ends with the term year If the semester code is not recognized, NA is assigned.
-
-**Parameters:**
-
-- `df` - Data frame containing term codes
-- `term_col` - Column name (unquoted or quoted) containing term codes
-
-**Returns:** Data frame with added `acad_year` column
+**Returns:** Invisibly: named list of save metadata for each table written
 
 ---
 
@@ -2096,6 +2897,7 @@ Get Unique Waitlisted Students Not Registered  Identifies students who are waitl
 
 - `filtered_students` - Data frame of student enrollments from cedar_students table, already filtered by opt parameters. Must include columns: campus, term, subject_course, course_title, student_id, registration_status
 - `opt` - Options list (currently unused but kept for consistency)
+- `sections` - Optional cedar_sections table; only needed if filtered_students lacks a course_title column (titles are joined by term/subject_course)
 
 **Returns:** Data frame with columns: \itemize{ \item \code{campus} - Campus code \item \code{subject_course} - Course identifier \item \code{count} - Number of unique students waitlisted only (not registered) } Sorted by campus, subject_course, and descending count.
 
@@ -2116,6 +2918,21 @@ waitlist_counts <- get_unique_waitlisted(filtered, opt)
 
 ---
 
+### `ensure_course_title()`
+
+*Source: waitlist.R*
+
+**Ensure course_title column is present for waitlist summaries**
+
+Ensure course_title column is present for waitlist summaries  cedar_students normally carries course_title; if the input lacks it, titles are joined from the sections table, which must then be supplied explicitly.
+
+**Parameters:**
+
+- `df` - Student enrollment rows.
+- `sections` - cedar_sections table; only required when df has no course_title.
+
+---
+
 ### `inspect_waitlist()`
 
 *Source: waitlist.R*
@@ -2128,6 +2945,7 @@ Inspect Waitlist by Major and Classification  Comprehensive waitlist analysis th
 
 - `students` - Data frame of student enrollments from cedar_students table. Must include columns: campus, college, term, term_type, major, student_classification, subject_course, course_title, level, registration_status
 - `opt` - Options list for filtering: \itemize{ \item \code{course} - Course identifier(s) (e.g., "MATH 1430") \item \code{term} - Term code(s) (e.g., 202510) \item \code{subject} - Subject code(s) (e.g., "MATH") \item Other filtering options supported by \code{filter_class_list()} }
+- `sections` - Optional cedar_sections table; only needed if students lacks a course_title column (titles are joined by term/subject_course)
 
 **Returns:** Named list with three elements: \itemize{ \item \code{majors} - Data frame summarizing waitlist by major/program. Columns: campus, term, subject_course, course_title, major, count \item \code{classifications} - Data frame summarizing waitlist by student level. Columns: campus, term, subject_course, course_title, student_classification, count \item \code{count} - Data frame of unique waitlisted students (see \code{\link{get_unique_waitlisted}}) }
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -31,7 +31,7 @@ Don't worry if you're still learning — the best way to learn is by doing. And 
 
 ```bash
 # Clone the repository
-git clone https://github.com/fredgibbs/cedar.git
+git clone https://github.com/cedar-collective/cedar.git
 cd cedar
 
 # Install dependencies (in R)
@@ -61,13 +61,17 @@ CEDAR is organized into a few key areas:
 ```
 cedar/
 ├── R/
-│   ├── cones/          # Analysis modules (enrollment, headcount, etc.)
-│   ├── branches/       # Shared utilities (filtering, loading, etc.)
-│   └── data-parsers/   # Data transformation scripts
+│   ├── lists/          # Static constants and lookups (grade codes, status codes, mappings)
+│   ├── trunk/          # Core infrastructure (filtering, term math, caching, logging, I/O)
+│   ├── branches/       # Reusable domain computations (enrollment, grades, populations)
+│   ├── cones/          # Focused analyses — each answers one question
+│   ├── reports/        # Orchestrators that assemble cones into rendered reports
+│   ├── modules/        # Shiny UI/server pairs for dashboard tabs
+│   └── data-parsers/   # Data transformation scripts (raw exports → CEDAR tables)
 ├── Rmd/                # Report templates
 ├── config/             # Configuration files
 ├── data/               # Data files (not in repo)
-├── tests/              # Test suite
+├── tests/              # Test suite (testthat + e2e browser tests)
 ├── ui.R                # Shiny UI
 ├── server.R            # Shiny server
 └── cedar.R             # CLI entry point
@@ -75,22 +79,34 @@ cedar/
 
 ## The "Cones" Concept
 
-CEDAR's architecture has three layers. At the base is the **trunk**: core utilities for loading, filtering, and transforming data — the logic that handles crosslisting, deduplication, term comparisons, and the structural details that every analysis needs to get right before the interesting work begins. Above that are the **branches**: domain-specific analytical functions for enrollment calculations, headcount, grade distributions, credit hour production, and other recurring computations that multiple analyses share. **Cones** sit at the top: focused, self-contained modules that answer specific questions by composing trunk and branch functions into a complete analysis.
+CEDAR's architecture is layered like a tree. At the base are the **lists** (static constants — grade codes, status codes, domain lookups) and the **trunk**: core utilities for loading, filtering, and transforming data — the logic that handles crosslisting, deduplication, term comparisons, and the structural details that every analysis needs to get right before the interesting work begins. Above that are the **branches**: domain-specific analytical functions for enrollment calculations, headcount, grade distributions, credit hour production, and other recurring computations that multiple analyses share. **Cones** sit at the top: focused, self-contained modules that answer specific questions by composing trunk and branch functions into a complete analysis. Two more layers turn analyses into things people use: **reports** assemble multiple cones into rendered output (department reports, course reports), and **modules** wire cones into the Shiny dashboard's tabs.
 
 Adding a cone for a new question means defining what you want to find out and assembling pieces that already exist — the underlying infrastructure doesn't change. Specific questions live in cones, reusable logic lives below them, and neither needs to know too much about the other. That separation is what keeps the system extensible, and what makes a cone developed at one institution adaptable at another.
 
-Current cones:
+Current cones (in `R/cones/`):
 
 | Cone | What It Does |
 |:-----|:-------------|
-| `enrl.R` | Enrollment analysis |
-| `headcount.R` | Student counts by program |
-| `credit-hours.R` | Credit hour calculations |
-| `sfr.R` | Student-faculty ratio |
-| `rollcall.R` | Student demographics |
-| `degrees.R` | Graduation data |
-| `dept-report.R` | Department reports |
-| `course-report.R` | Course reports |
+| `bottleneck.R` | Waitlist pressure and unmet enrollment demand |
+| `cancellations.R` | Cancelled course sections |
+| `course-demographics.R` | Major and classification breakdown per course |
+| `course-impact.R` | Observational comparisons: persistence and downstream grades for students who took a course vs. comparable students who didn't |
+| `course-neighbors.R` | What students take before, after, and alongside a course |
+| `course-outcomes.R` | Next-term persistence by grade, DFW trends, instructor DFW comparison |
+| `course-retention.R` | Descriptive next-term retention rates across courses |
+| `forecast/` | Course enrollment forecasting |
+| `gen-ed-conversion.R` | Where students who took gen-ed courses ended up (major flows) |
+| `gened-fulfillment.R` | Gen-ed area fulfillment by major |
+| `health-whatif.R` | Health-program course demand and what-if enrollment projections |
+| `major-changes.R` | Major-change detection, timing, and pathways |
+| `pathway.R` | When students in a population take each course; course sequences |
+| `population-trend.R` | Entry-type distribution over time |
+| `seatfinder.R` | Seat availability across terms |
+| `sfr.R` | Faculty FTE by department |
+| `stopout.R` | Stop-out rates after DFW vs. passing outcomes |
+| `waitlist.R` | Waitlist counts by course and major |
+
+The full function-level reference — including the branch and report layers — is in the auto-generated [Function Reference](functions.html); the architecture rules live in `AGENTS.md` at the repository root.
 
 ## CEDAR Data Model
 
@@ -110,7 +126,7 @@ This model is institution-agnostic. See [Data Model](data-model.html) for the fu
 
 We welcome contributions of all sizes:
 
-- **Report bugs** — Found something broken? [Open an issue](https://github.com/fredgibbs/cedar/issues)
+- **Report bugs** — Found something broken? [Open an issue](https://github.com/cedar-collective/cedar/issues)
 - **Suggest features** — Have an idea? We'd love to hear it
 - **Improve docs** — See something unclear? PRs welcome
 - **Add tests** — Help us improve coverage

--- a/docs/developers/installation.md
+++ b/docs/developers/installation.md
@@ -23,7 +23,7 @@ This guide walks you through setting up CEDAR for local development.
 ## Step 1: Clone the Repository
 
 ```bash
-git clone https://github.com/fredgibbs/cedar.git
+git clone https://github.com/cedar-collective/cedar.git
 cd cedar
 ```
 

--- a/scripts/generate-function-docs.R
+++ b/scripts/generate-function-docs.R
@@ -4,16 +4,17 @@
 #' This script extracts roxygen2 documentation from R files and generates
 #' Jekyll-compatible markdown files for the docs site.
 #'
-#' Usage: Rscript scripts/generate-function-docs.R
+#' Usage: LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 Rscript --vanilla scripts/generate-function-docs.R
+#'   (the explicit locale matters: --vanilla does not inherit one, and roxygen
+#'    comments contain UTF-8 characters that crash sub() under the C locale)
 #'
-#' Output: docs/reference/functions.md (combined reference)
-#'         docs/reference/functions/ (individual function files)
+#' Output: docs/developers/functions.md (combined reference)
 
 library(stringr)
 
 # Configuration
 R_DIRS <- c("R/cones", "R/branches", "R/data-parsers")
-OUTPUT_DIR <- "docs/reference"
+OUTPUT_DIR <- "docs/developers"
 COMBINED_OUTPUT <- file.path(OUTPUT_DIR, "functions.md")
 
 #' Parse a single R file and extract roxygen blocks
@@ -277,8 +278,8 @@ main <- function() {
   md <- c(
     "---",
     "title: Function Reference",
-    "nav_order: 3",
-    "parent: Reference",
+    "nav_order: 4",
+    "parent: Developer Guide",
     "---",
     "",
     "# CEDAR Function Reference",


### PR DESCRIPTION
## What changed

**New: `ROADMAP.md`** — a strategic priorities document from a full project audit (2026-07-12) covering code, documentation, UX, testing, and operations. It sits above the two existing working docs: AGENTS.md stays the architecture reference, NEXT-STEPS.md stays the tactical work queue, and ROADMAP.md says where effort should go and why. Highlights:

- Five strategic themes, led by **internal reconciliation as the product promise**: the open GitHub issues (#31, #32) show users unable to reconcile CEDAR tabs with each other — exactly the problem CEDAR exists to solve.
- A triage of all 11 open GitHub issues grouped by root cause (reconciliation, mapping gaps, feature requests, plot polish).
- A verified documentation-debt inventory, testing gaps, ops/hygiene items, and a Now / Next / Later sequencing.

**AGENTS.md truth pass** — the authoritative reference had fallen behind the code:

- Cone table now includes the four missing cones: `cancellations.R`, `gen-ed-conversion.R`, `health-whatif.R` (the entire Healthcare tab, previously undocumented), and the `forecast/` subdirectory.
- Branch table adds `course-flows.R` and `pathways.R`; report table adds `gen-ed.R` and corrects the course-report entry points (`create_course_report_data(data_objects, opt)`, not the nonexistent `get_course_report_data()`).
- New **module inventory** covering all 11 modules, including that the Retention module UI is intentionally commented out and Healthcare mounts under Admin.
- Fixed stale references to `lookout.R` (deleted long ago) and `cohortBuilderUI/Server` (actual: `populationSelectorUI/Server`).
- Replaced the drifted Phase 1–4 "Refactoring Status" checklists with a pointer to NEXT-STEPS.md so there is exactly one status list. Still-open items were carried over, not dropped: Rmd comment cleanup is now NEXT-STEPS **E4**, and the externalize-domain-data items are new section **F (F1–F3)**.

**Developer docs refresh:**

- Repo URLs fixed (`github.com/fredgibbs/cedar` → `github.com/cedar-collective/cedar`) in index, contributing, installation.
- `docs/developers/index.md` rewritten for the six-layer architecture (it described three layers) with the real cone list (the old table listed branches, reports, and the pre-rename `rollcall.R` as cones).
- Function-reference generator fixed: it wrote to `docs/reference/` (a path that does not exist) with wrong Jekyll front matter. `functions.md` regenerated — **132 documented functions, up from 77**, replacing a February snapshot.

## Notes for review

- The regenerated `functions.md` accounts for most of the diff size; it is machine-generated from roxygen comments.
- The generator needs an explicit UTF-8 locale under `Rscript --vanilla` (it crashes on `→` in roxygen otherwise); documented in the script's usage note.
- This was cherry-picked onto current main and auto-merged cleanly with the designed-test-data fixture workflow changes from #55/#56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
