### PR TITLE
Issue #32: pin the combined-course vs-average fix and never merge campuses

### DIFF
--- a/R/reports/dept-dashboard.R
+++ b/R/reports/dept-dashboard.R
@@ -494,12 +494,13 @@ plot_majors_with_dept_minor <- function(cedar_programs, dept_code, top_n = 8) {
 #' \code{get_dept_course_enrl_history()} (recommended, avoids re-querying
 #' cedar_sections) or falls back to building it from cedar_sections directly.
 #'
-#' @param course_history Data frame returned by \code{get_dept_course_enrl_history()}.
-#'   Columns: subject_course, course_title, term, enrolled.
+#' @param course_history Per-campus course enrollment history (campus column
+#'   required — campuses are never merged; each campus trends independently).
+#'   Columns: subject_course, course_title, campus, term, enrolled.
 #' @param n_terms Number of most-recent terms per course to use for trend (default 6).
 #' @param threshold Minimum absolute slope to call a trend up or down (default 1).
 #' @return Named list: growing (data frame), investigate (data frame),
-#'   each with columns: subject_course, course_title, n_terms, avg_enrl,
+#'   each with columns: subject_course, course_title, campus, n_terms, avg_enrl,
 #'   avg_enrl_early, avg_enrl_recent, change_abs, change_pct, trend_slope.
 get_enrollment_momentum <- function(course_history, n_terms = 6, threshold = 1) {
   message("[dept-dashboard.R] get_enrollment_momentum")
@@ -507,12 +508,13 @@ get_enrollment_momentum <- function(course_history, n_terms = 6, threshold = 1) 
   if (is.null(course_history) || nrow(course_history) == 0) {
     return(list(growing = NULL, investigate = NULL))
   }
+  .assert_history_has_campus(course_history, "get_enrollment_momentum")
 
   # Compute trend per course using the last n_terms offerings.
   # avg_enrl_early = avg of first half of the window (baseline)
   # avg_enrl_recent = avg of second half (current)
   course_trends <- course_history %>%
-    dplyr::group_by(subject_course, course_title) %>%
+    dplyr::group_by(subject_course, course_title, campus) %>%
     dplyr::arrange(term) %>%
     dplyr::slice_tail(n = n_terms) %>%
     dplyr::summarize(
@@ -577,8 +579,9 @@ get_new_courses <- function(course_history, new_within_years = 2) {
   # Convert year cutoff to a term lower bound (e.g., 2 years ago → 202200)
   new_term_cutoff <- (current_year - new_within_years) * 100
 
+  .assert_history_has_campus(course_history, "get_new_courses")
   result <- course_history %>%
-    dplyr::group_by(subject_course, course_title) %>%
+    dplyr::group_by(subject_course, course_title, campus) %>%
     dplyr::summarize(
       first_term = min(term),
       last_term  = max(term),
@@ -622,8 +625,9 @@ get_dormant_courses <- function(course_history, dormant_terms = 4, min_history_t
   # their last offering BEFORE this term.
   cutoff_term <- all_terms[length(all_terms) - dormant_terms + 1]
 
+  .assert_history_has_campus(course_history, "get_dormant_courses")
   result <- course_history %>%
-    dplyr::group_by(subject_course, course_title) %>%
+    dplyr::group_by(subject_course, course_title, campus) %>%
     dplyr::summarize(
       last_term  = max(term),
       first_term = min(term),
@@ -643,6 +647,23 @@ get_dormant_courses <- function(course_history, dormant_terms = 4, min_history_t
 # of *right now*: which courses are running above/below their historical
 # average, what's new this term, and what ran last year but isn't running now.
 # Historical trend lists (growing/declining) live on the Enrollment page.
+#
+# CAMPUS RULE: campuses are never merged. course_history must carry a campus
+# column (built with campus in group_cols), and every comparison here is
+# per-campus — an ABQ offering compares only to prior ABQ offerings. Merging
+# would sum campuses in "all campuses" views (e.g. a course that once ran at
+# two campuses would inflate its own historical average — issue #32 follow-up).
+
+# Stop loudly if course_history was built without the campus column.
+.assert_history_has_campus <- function(course_history, caller) {
+  required <- c("subject_course", "course_title", "term", "campus")
+  missing  <- setdiff(required, names(course_history))
+  if (length(missing) > 0) {
+    stop("[", caller, "] course_history is missing required column(s): ",
+         paste(missing, collapse = ", "),
+         ". Build it with campus in group_cols — campuses are never merged.")
+  }
+}
 
 #' Compare current-term enrollment to historical averages
 #'
@@ -655,10 +676,13 @@ get_dormant_courses <- function(course_history, dormant_terms = 4, min_history_t
 #' 60 = summer, 80 = fall. This ensures fall courses are only compared against
 #' prior falls, not against spring or summer offerings.
 #'
-#' @param course_history Data frame from \code{get_dept_course_enrl_history()}.
+#' @param course_history Per-campus course enrollment history (one row per
+#'   subject_course × course_title × campus × term; see the ch_opt build in
+#'   \code{create_dept_dashboard_data()}). The campus column is required —
+#'   campuses are never merged, so each campus compares to its own history.
 #' @param current_term Integer term code (e.g. \code{cedar_current_term}).
 #' @return Named list: \code{above} and \code{below}, each a data frame with
-#'   columns: subject_course, course_title, enrolled, hist_avg_enrl,
+#'   columns: subject_course, course_title, campus, enrolled, hist_avg_enrl,
 #'   diff, pct_diff. Returns \code{list(above = NULL, below = NULL)} if no data.
 get_current_enrl_vs_avg <- function(course_history, current_term) {
   message("[dept-dashboard.R] get_current_enrl_vs_avg for term ", current_term)
@@ -666,6 +690,7 @@ get_current_enrl_vs_avg <- function(course_history, current_term) {
   if (is.null(course_history) || nrow(course_history) == 0) {
     return(list(above = NULL, below = NULL))
   }
+  .assert_history_has_campus(course_history, "get_current_enrl_vs_avg")
 
   current <- course_history %>% dplyr::filter(term == current_term)
   if (nrow(current) == 0) {
@@ -683,7 +708,7 @@ get_current_enrl_vs_avg <- function(course_history, current_term) {
   # a label mismatch for crosslisted courses (e.g. home enrolled=8, total=15).
   hist_avg <- course_history %>%
     dplyr::filter(term != current_term, term %% 100 == current_season) %>%
-    dplyr::group_by(subject_course, course_title) %>%
+    dplyr::group_by(subject_course, course_title, campus) %>%
     dplyr::summarize(
       hist_avg_enrl = round(mean(total_enrl, na.rm = TRUE), 1),
       n_hist        = dplyr::n(),
@@ -692,7 +717,7 @@ get_current_enrl_vs_avg <- function(course_history, current_term) {
     dplyr::filter(n_hist >= 2)  # need at least 2 prior same-season terms for a meaningful avg
 
   comparison <- current %>%
-    dplyr::inner_join(hist_avg, by = c("subject_course", "course_title")) %>%
+    dplyr::inner_join(hist_avg, by = c("subject_course", "course_title", "campus")) %>%
     dplyr::mutate(
       diff     = as.integer(round(total_enrl - hist_avg_enrl)),
       pct_diff = dplyr::if_else(
@@ -721,12 +746,16 @@ get_current_enrl_vs_avg <- function(course_history, current_term) {
 #' established course number counts as a new course. Recurring topics are also
 #' surfaced separately by \code{get_repeated_topics_courses()}.
 #'
-#' @param course_history Data frame from \code{get_dept_course_enrl_history()}.
+#' @param course_history Per-campus course enrollment history (campus column
+#'   required). Newness is judged course-level — a course that ever ran at ANY
+#'   campus is not "new" — but enrollment is reported per campus, never summed
+#'   across campuses.
 #' @param current_term Integer term code.
-#' @return Data frame with columns: subject_course, course_title, enrolled,
-#'   slot_avg_enrl (NA for non-topics; average enrollment across all prior T:
-#'   offerings under same course number), n_slot_prior (count of those prior
-#'   offerings). Ordered alphabetically. Returns NULL if none found.
+#' @return Data frame with columns: subject_course, course_title, campus,
+#'   enrolled, slot_avg_enrl (NA for non-topics; average enrollment across all
+#'   prior T: offerings under same course number at the same campus),
+#'   n_slot_prior (count of those prior offerings). Ordered alphabetically.
+#'   Returns NULL if none found.
 get_new_this_term <- function(course_history, current_term) {
   message("[dept-dashboard.R] get_new_this_term for term ", current_term)
 
@@ -734,10 +763,11 @@ get_new_this_term <- function(course_history, current_term) {
     message("[dept-dashboard.R] get_new_this_term: no course history (returning NULL)")
     return(NULL)
   }
+  .assert_history_has_campus(course_history, "get_new_this_term")
 
   current_courses <- course_history %>%
     dplyr::filter(term == current_term) %>%
-    dplyr::select(subject_course, course_title, enrolled, dplyr::any_of("total_enrl"))
+    dplyr::select(subject_course, course_title, campus, enrolled, dplyr::any_of("total_enrl"))
 
   if (nrow(current_courses) == 0) {
     message("[dept-dashboard.R] get_new_this_term: no courses in current term ", current_term, " (returning NULL)")
@@ -768,18 +798,19 @@ get_new_this_term <- function(course_history, current_term) {
       dplyr::anti_join(prior_topic_keys, by = c("subject_course", "course_title"))
 
     # Slot average: avg enrollment across ALL prior T: offerings for same course number,
-    # regardless of title — tells the chair what demand for this slot typically looks like.
+    # regardless of title — tells the chair what demand for this slot typically looks
+    # like. Per campus: demand at one campus says nothing about another.
     if (nrow(topics_new) > 0) {
       slot_avgs <- prior_history %>%
         dplyr::filter(is_topics_course(course_title)) %>%
-        dplyr::group_by(subject_course) %>%
+        dplyr::group_by(subject_course, campus) %>%
         dplyr::summarize(
           slot_avg_enrl = round(mean(enrolled, na.rm = TRUE), 1),
           n_slot_prior  = dplyr::n(),
           .groups = "drop"
         )
       topics_new <- topics_new %>%
-        dplyr::left_join(slot_avgs, by = "subject_course")
+        dplyr::left_join(slot_avgs, by = c("subject_course", "campus"))
     } else {
       topics_new <- NULL
     }
@@ -821,7 +852,7 @@ term_label <- function(term) {
   if (topics_only) data <- data %>% dplyr::filter(is_topics_course(course_title))
   data %>%
     dplyr::arrange(dplyr::desc(term)) %>%
-    dplyr::group_by(subject_course, course_title) %>%
+    dplyr::group_by(subject_course, course_title, campus) %>%
     dplyr::slice_head(n = 3) %>%
     dplyr::summarize(
       recent_history = paste(paste0(sapply(term, term_label), ":", enrolled), collapse = " • "),
@@ -841,13 +872,16 @@ term_label <- function(term) {
 #' function trusts that \code{course_history} already contains only home-dept
 #' sections and does no additional crosslist logic.
 #'
-#' @param course_history Data frame from \code{get_dept_course_enrl_history()}.
+#' @param course_history Per-campus course enrollment history (campus column
+#'   required). Absence is judged per campus: a course that ran at ABQ and EA
+#'   two years ago but runs only at ABQ now is reported missing at EA.
 #' @param current_term Integer term code.
 #' @param years_back Number of years back to compare (default 2). Term code
 #'   arithmetic: \code{current_term - years_back * 100}.
-#' @return Data frame with columns: subject_course, course_title, prior_enrl
-#'   (enrollment in the comparison term), recent_history (last 3 prior
-#'   appearances as a formatted string, e.g. "F24:28 • Sp22:31 • F20:24").
+#' @return Data frame with columns: subject_course, course_title, campus,
+#'   prior_enrl (enrollment in the comparison term at that campus),
+#'   recent_history (last 3 prior appearances at that campus as a formatted
+#'   string, e.g. "F24:28 • Sp22:31 • F20:24").
 #'   Returns NULL if none found or if the comparison term has no data.
 get_missing_from_earlier <- function(course_history, current_term, years_back = 2) {
   prior_term <- current_term - (years_back * 100L)
@@ -858,10 +892,11 @@ get_missing_from_earlier <- function(course_history, current_term, years_back = 
     message("[dept-dashboard.R] get_missing_from_earlier: no course history (returning NULL)")
     return(NULL)
   }
+  .assert_history_has_campus(course_history, "get_missing_from_earlier")
 
   comparison_term_data <- course_history %>%
     dplyr::filter(term == prior_term) %>%
-    dplyr::select(subject_course, course_title, prior_enrl = enrolled)
+    dplyr::select(subject_course, course_title, campus, prior_enrl = enrolled)
 
   if (nrow(comparison_term_data) == 0) {
     message("[dept-dashboard.R] No data for comparison term ", prior_term)
@@ -870,10 +905,10 @@ get_missing_from_earlier <- function(course_history, current_term, years_back = 
 
   current_course_keys <- course_history %>%
     dplyr::filter(term == current_term) %>%
-    dplyr::distinct(subject_course, course_title)
+    dplyr::distinct(subject_course, course_title, campus)
 
   result <- comparison_term_data %>%
-    dplyr::anti_join(current_course_keys, by = c("subject_course", "course_title")) %>%
+    dplyr::anti_join(current_course_keys, by = c("subject_course", "course_title", "campus")) %>%
     dplyr::arrange(subject_course)
 
   if (nrow(result) == 0) {
@@ -881,10 +916,10 @@ get_missing_from_earlier <- function(course_history, current_term, years_back = 
     return(NULL)
   }
 
-  # Add recent_history: last 3 prior appearances per course across all history
+  # Add recent_history: last 3 prior appearances per course+campus across all history
   recent <- .recent_history_str(course_history, current_term)
 
-  result %>% dplyr::left_join(recent, by = c("subject_course", "course_title"))
+  result %>% dplyr::left_join(recent, by = c("subject_course", "course_title", "campus"))
 }
 
 
@@ -938,11 +973,12 @@ get_headcount_series <- function(cedar_programs, dept_code) {
 #' terms. Surfaces recurring topics — established enough to have a track record
 #' but still rotating content.
 #'
-#' @param course_history Data frame from \code{get_dept_course_enrl_history()}.
+#' @param course_history Per-campus course enrollment history (campus column
+#'   required). Prior offerings and averages are counted per campus.
 #' @param current_term Integer term code.
 #' @param min_prior Minimum prior offerings required (default 2).
-#' @return Data frame with columns: subject_course, course_title, enrolled,
-#'   prior_offerings, avg_prior_enrl. Returns NULL if none found.
+#' @return Data frame with columns: subject_course, course_title, campus,
+#'   enrolled, prior_offerings, avg_prior_enrl. Returns NULL if none found.
 get_repeated_topics_courses <- function(course_history, current_term, min_prior = 2) {
   message("[dept-dashboard.R] get_repeated_topics_courses for term ", current_term)
 
@@ -950,10 +986,11 @@ get_repeated_topics_courses <- function(course_history, current_term, min_prior 
     message("[dept-dashboard.R] get_repeated_topics_courses: no course history (returning NULL)")
     return(NULL)
   }
+  .assert_history_has_campus(course_history, "get_repeated_topics_courses")
 
   current_topics <- course_history %>%
     dplyr::filter(term == current_term, is_topics_course(course_title)) %>%
-    dplyr::select(subject_course, course_title, enrolled, dplyr::any_of("total_enrl"))
+    dplyr::select(subject_course, course_title, campus, enrolled, dplyr::any_of("total_enrl"))
 
   if (nrow(current_topics) == 0) {
     message("[dept-dashboard.R] get_repeated_topics_courses: no topics courses in current term ", current_term, " (returning NULL)")
@@ -962,7 +999,7 @@ get_repeated_topics_courses <- function(course_history, current_term, min_prior 
 
   prior_counts <- course_history %>%
     dplyr::filter(term != current_term, is_topics_course(course_title)) %>%
-    dplyr::group_by(subject_course, course_title) %>%
+    dplyr::group_by(subject_course, course_title, campus) %>%
     dplyr::summarize(
       prior_offerings  = dplyr::n(),
       avg_prior_enrl   = round(mean(enrolled, na.rm = TRUE), 1),
@@ -971,7 +1008,7 @@ get_repeated_topics_courses <- function(course_history, current_term, min_prior 
     dplyr::filter(prior_offerings >= min_prior)
 
   result <- current_topics %>%
-    dplyr::inner_join(prior_counts, by = c("subject_course", "course_title")) %>%
+    dplyr::inner_join(prior_counts, by = c("subject_course", "course_title", "campus")) %>%
     dplyr::arrange(dplyr::desc(prior_offerings), subject_course)
 
   if (nrow(result) == 0) {
@@ -982,7 +1019,7 @@ get_repeated_topics_courses <- function(course_history, current_term, min_prior 
   # Add last 3 prior appearances with enrollment (mirrors get_missing_from_earlier)
   recent <- .recent_history_str(course_history, current_term, topics_only = TRUE)
 
-  result %>% dplyr::left_join(recent, by = c("subject_course", "course_title"))
+  result %>% dplyr::left_join(recent, by = c("subject_course", "course_title", "campus"))
 }
 
 
@@ -1578,12 +1615,17 @@ create_dept_dashboard_data <- function(data_objects, opt) {
   result$plots$credit_hours_by_level <-
     plot_credit_hours_by_level(cedar_students, dept_code, n_years = 5, campus = campus)
 
-  # Build course enrollment history via get_enrl (one row per course per term, enrolled > 0).
-  # crosslist = "home" keeps only home-dept sections; uel = TRUE drops thesis/dissertation/honors.
+  # Build course enrollment history via get_enrl (one row per course per campus per
+  # term, enrolled > 0). crosslist = "home" keeps only home-dept sections; uel = TRUE
+  # drops thesis/dissertation/honors. campus is in group_cols because campuses are
+  # never merged: in "all campuses" views each campus compares to its own history
+  # (see the CAMPUS RULE note above the snapshot functions).
   ch_opt <- list(dept = dept_code, status = "A", crosslist = "home", uel = TRUE,
-                 group_cols = c("subject_course", "course_title", "term"))
+                 group_cols = c("subject_course", "course_title", "campus", "term"))
   if (!is.null(campus) && length(campus) > 0) ch_opt$course_campus <- campus
-  course_history <- get_enrl(cedar_sections, ch_opt) %>% dplyr::filter(enrolled > 0)
+  # ungroup: get_enrl returns grouped data (see filter/dplyr gotchas in AGENTS.md)
+  course_history <- get_enrl(cedar_sections, ch_opt) %>%
+    dplyr::ungroup() %>% dplyr::filter(enrolled > 0)
 
   # Current-term snapshot — reads cedar_current_term from global config.
   # Falls back to max term in history if not defined (e.g. in testing).

--- a/server.R
+++ b/server.R
@@ -722,11 +722,14 @@ observeEvent(input$enrl_copy_url, {
     term <- if (!is.null(input$enrl_term) && length(input$enrl_term) > 0) input$enrl_term else NULL
 
     tryCatch({
+      # campus in group_cols: campuses are never merged — each campus trends
+      # against its own history (see CAMPUS RULE in dept-dashboard.R).
       opt <- list(dept = dept, status = "A", crosslist = "home", uel = TRUE,
-                  group_cols = c("subject_course", "course_title", "term"))
+                  group_cols = c("subject_course", "course_title", "campus", "term"))
       if (!is.null(term))   opt$term          <- term
       if (!is.null(campus)) opt$course_campus  <- campus
-      history <- get_enrl(cedar_sections, opt) %>% dplyr::filter(enrolled > 0)
+      history <- get_enrl(cedar_sections, opt) %>%
+        dplyr::ungroup() %>% dplyr::filter(enrolled > 0)
       momentum <- get_enrollment_momentum(history)
       list(growing = momentum$growing, investigate = momentum$investigate, history = history)
     }, error = function(e) {
@@ -752,11 +755,17 @@ observeEvent(input$enrl_copy_url, {
     if (is.null(courses) || nrow(courses) == 0 || is.null(history) || nrow(history) == 0)
       return(NULL)
     top_courses <- utils::head(courses, n)$subject_course
+    # One line per campus when the (unfiltered) history spans several campuses —
+    # summing campuses into one line would merge them (campuses are never merged).
+    multi_campus <- dplyr::n_distinct(history$campus) > 1
     plot_data <- history %>%
       dplyr::filter(subject_course %in% top_courses) %>%
       dplyr::mutate(
         term_label   = vapply(as.character(term), abbr_term, character(1)),
-        course_label = paste0(subject_course, ": ", course_title)
+        course_label = if (multi_campus)
+          paste0(subject_course, " (", campus, "): ", course_title)
+        else
+          paste0(subject_course, ": ", course_title)
       ) %>%
       dplyr::arrange(term)
     if (nrow(plot_data) == 0) return(NULL)
@@ -3924,6 +3933,14 @@ output$enrl_summary_download <- downloadHandler(
     )
   }
 
+  # Campus tag for dashboard course rows. Course history is per-campus (campuses
+  # are never merged), so in an "all campuses" view the same course can appear
+  # once per campus — tag the rows whenever a table spans more than one campus.
+  .campus_suffix <- function(r, x) {
+    if (!"campus" %in% names(x) || dplyr::n_distinct(x$campus) <= 1) return("")
+    paste0(" (", r$campus, ")")
+  }
+
   # Render a standard dashboard course table, capping at max_rows (default: .dash_max_rows).
   # Pass max_rows = Inf to render all rows without a cap.
   # row_fn(i, data) should return a tags$tr() for row i.
@@ -3943,7 +3960,7 @@ output$enrl_summary_download <- downloadHandler(
       diff_str <- fmt_enrl_diff(r$diff, r$pct_diff)
       tags$tr(
         tags$td(style = "padding: 2px 6px 2px 0; font-weight: 600; white-space: nowrap;",
-                r$subject_course),
+                paste0(r$subject_course, .campus_suffix(r, x))),
         tags$td(style = "padding: 2px 4px; color: #555;", r$course_title),
         tags$td(style = "padding: 2px 4px; text-align: right; white-space: nowrap;",
                 paste0(r$total_enrl, " enrolled")),
@@ -3963,7 +3980,7 @@ output$enrl_summary_download <- downloadHandler(
       diff_str <- fmt_enrl_diff(r$diff, r$pct_diff)
       tags$tr(
         tags$td(style = "padding: 2px 6px 2px 0; font-weight: 600; white-space: nowrap;",
-                r$subject_course),
+                paste0(r$subject_course, .campus_suffix(r, x))),
         tags$td(style = "padding: 2px 4px; color: #555;", r$course_title),
         tags$td(style = "padding: 2px 4px; text-align: right; white-space: nowrap;",
                 paste0(r$total_enrl, " enrolled")),
@@ -3987,7 +4004,7 @@ output$enrl_summary_download <- downloadHandler(
         else ""
       tags$tr(
         tags$td(style = "padding: 2px 6px 2px 0; font-weight: 600; white-space: nowrap;",
-                r$subject_course),
+                paste0(r$subject_course, .campus_suffix(r, x))),
         tags$td(style = "padding: 2px 4px; color: #555;", r$course_title),
         tags$td(style = "padding: 2px 4px; text-align: right; white-space: nowrap; color: #1565c0;",
                 paste0(r$total_enrl, " enrolled")),
@@ -4008,7 +4025,7 @@ output$enrl_summary_download <- downloadHandler(
       hist_txt <- if (!is.na(r$recent_history)) r$recent_history else paste0("last seen: ", r$prior_enrl)
       tags$tr(
         tags$td(style = "padding: 2px 6px 2px 0; font-weight: 600; white-space: nowrap;",
-                r$subject_course),
+                paste0(r$subject_course, .campus_suffix(r, x))),
         tags$td(style = "padding: 2px 4px; color: #555;", r$course_title),
         tags$td(style = "padding: 2px 0 2px 6px; text-align: right; white-space: nowrap; color: #888;",
                 hist_txt)
@@ -4028,7 +4045,7 @@ output$enrl_summary_download <- downloadHandler(
         r$recent_history else paste0("avg ", r$avg_prior_enrl)
       tags$tr(
         tags$td(style = "padding: 2px 6px 2px 0; font-weight: 600; white-space: nowrap;",
-                r$subject_course),
+                paste0(r$subject_course, .campus_suffix(r, x))),
         tags$td(style = "padding: 2px 4px; color: #555;", r$course_title),
         tags$td(style = "padding: 2px 4px; text-align: right; white-space: nowrap;",
                 paste0(r$total_enrl, " enrolled")),

--- a/tests/testthat/fixtures/designed_test_data.R
+++ b/tests/testthat/fixtures/designed_test_data.R
@@ -46,7 +46,7 @@
 #   "202010-202060" = 34    "202010-202110" = 71
 #   "spring" = 40  "summer" = 14  "fall" = 17
 #
-# XL rows (20 rows, built as cedar_sections_xl below then merged in):
+# XL rows (21 rows, built as cedar_sections_xl below then merged in):
 #
 # Five crosslist/split scenarios for test-crosslist-split.R:
 #   XL01 — cross-dept, same level: HIST 480 (primary,12) + ANTH 480 (0)
@@ -58,13 +58,15 @@
 #   XL06-S — ANTH 2190C spring history for get_current_enrl_vs_avg (issue #32):
 #           internal-crosslist pairs in 201910 (total 52), 202010 (50), 202110 (47)
 #           → prior-spring avg 51 vs current 47. 201910 exists ONLY for these rows.
+#   XL06-EA — ANTH 2190C at EA in 201910 (single row, enrolled 20, no crosslist):
+#           proves campuses are never merged (ABQ avg stays 51, not (72+50)/2).
 #   EC-04 — Pattern A non-crosslisted C: BIOL 2110C (4 CRNs, enrolled=22/22/23/22, total_enrl=89)
 #   EC-05 — Pattern B non-crosslisted C: BIOL 304C  (4 CRNs, enrolled=25/22/22/20, total_enrl=same)
 #   EC-06 — Pattern C internal crosslist C: BIOL 300C (2 groups × 3 CRNs; group 6G sum=92, group 62 sum=138)
 #   EC-07 — internal crosslist, NOT combined: BIOL 2305 (1 group × 3 CRNs; enrolled=24/24/23,
 #           total_enrl=71 on every row — correct course total counts the group once, not 3×71)
-# XL crosslist_primary=TRUE: 9  |  is_split=TRUE: 7  |  crosslist_external=TRUE: 6
-# is_combined=TRUE: 23 (XL06=3, XL06-S=6, EC-04=4, EC-05=4, EC-06=6); internal non-combined: EC-07=3
+# XL crosslist_primary=TRUE: 10 (incl. non-crosslisted XL06-EA)  |  is_split=TRUE: 7  |  crosslist_external=TRUE: 6
+# is_combined=TRUE: 24 (XL06=3, XL06-S=6, XL06-EA=1, EC-04=4, EC-05=4, EC-06=6); internal non-combined: EC-07=3
 # Tests filter with filter(!is.na(crosslist_group)) to get this subset.
 #
 # === CEDAR_STUDENTS ===
@@ -1278,7 +1280,24 @@ cedar_sections_xl <- tribble(
   4.0,4.0, as.Date("2021-01-18"),as.Date("2021-05-14"),
   "D9","D9","internal",
   FALSE,NA_character_,NA_character_,
-  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2021-01-18")
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2021-01-18"),
+
+  # --- XL06-EA: same course at a DIFFERENT campus (campuses are never merged) ---
+  # A single EA offering of ANTH 2190C in 201910 (enrolled 20, no crosslist).
+  # The ABQ spring average must stay (52+50)/2 = 51 — if any dashboard history
+  # merged campuses, this row would inflate 201910 to 72 and shift the average.
+  # EA has no other springs, so it can never clear the n_hist >= 2 gate itself.
+  "XL0610", 201910L, "XL021", "ANTH","2190C","ANTH 2190C","004",
+  "Forensic Anthropology",           "1","EA","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  20L,20L,26L,6L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  TRUE,  FALSE,
+  4.0,4.0, as.Date("2019-01-14"),as.Date("2019-05-11"),
+  NA_character_,NA_character_,NA_character_,
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2019-01-14")
 )
 
 # Merge XL sections into the main table. In production, crosslisted sections live

--- a/tests/testthat/fixtures/designed_test_data.R
+++ b/tests/testthat/fixtures/designed_test_data.R
@@ -46,7 +46,7 @@
 #   "202010-202060" = 34    "202010-202110" = 71
 #   "spring" = 40  "summer" = 14  "fall" = 17
 #
-# XL rows (14 rows, built as cedar_sections_xl below then merged in):
+# XL rows (20 rows, built as cedar_sections_xl below then merged in):
 #
 # Five crosslist/split scenarios for test-crosslist-split.R:
 #   XL01 — cross-dept, same level: HIST 480 (primary,12) + ANTH 480 (0)
@@ -54,14 +54,17 @@
 #   XL03 — split-level, grad primary: AMST 499 (0) + AMST 599 (primary,5)
 #   XL04 — zero-enrl alpha tiebreak:  ANTH 490 (primary) + HIST 490 (both 0)
 #   XL05 — three-way split-level: HIST 475 (primary,10) + AMST 475 (0) + HIST 575 (0)
-#   XL06 — combined C-suffix: ANTH 2190C (3 CRNs, primary enrolled=16, total_enrl=47)
+#   XL06 — combined C-suffix: ANTH 2190C fall 202080 (3 CRNs, primary enrolled=16, total_enrl=47)
+#   XL06-S — ANTH 2190C spring history for get_current_enrl_vs_avg (issue #32):
+#           internal-crosslist pairs in 201910 (total 52), 202010 (50), 202110 (47)
+#           → prior-spring avg 51 vs current 47. 201910 exists ONLY for these rows.
 #   EC-04 — Pattern A non-crosslisted C: BIOL 2110C (4 CRNs, enrolled=22/22/23/22, total_enrl=89)
 #   EC-05 — Pattern B non-crosslisted C: BIOL 304C  (4 CRNs, enrolled=25/22/22/20, total_enrl=same)
 #   EC-06 — Pattern C internal crosslist C: BIOL 300C (2 groups × 3 CRNs; group 6G sum=92, group 62 sum=138)
 #   EC-07 — internal crosslist, NOT combined: BIOL 2305 (1 group × 3 CRNs; enrolled=24/24/23,
 #           total_enrl=71 on every row — correct course total counts the group once, not 3×71)
-# XL crosslist_primary=TRUE: 6  |  is_split=TRUE: 7  |  crosslist_external=TRUE: 6
-# is_combined=TRUE: 17 (XL06=3, EC-04=4, EC-05=4, EC-06=6); internal non-combined: EC-07=3
+# XL crosslist_primary=TRUE: 9  |  is_split=TRUE: 7  |  crosslist_external=TRUE: 6
+# is_combined=TRUE: 23 (XL06=3, XL06-S=6, EC-04=4, EC-05=4, EC-06=6); internal non-combined: EC-07=3
 # Tests filter with filter(!is.na(crosslist_group)) to get this subset.
 #
 # === CEDAR_STUDENTS ===
@@ -1194,7 +1197,88 @@ cedar_sections_xl <- tribble(
   4.0,4.0, as.Date("2020-08-17"),as.Date("2020-12-12"),
   "E7","E7","internal",
   FALSE,NA_character_,NA_character_,
-  FALSE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17")
+  FALSE,FALSE,NA_character_,NA_integer_,as.Date("2020-08-17"),
+
+  # --- XL06-S: ANTH 2190C spring history — internal crosslist combined (issue #32) ---
+  # Three springs of the same combined course so get_current_enrl_vs_avg() has a
+  # same-season history (n_hist >= 2) with 202110 as the "current" term. Mirrors
+  # the real ANTH 2190C shape from issue #32: internal crosslist group where every
+  # row carries the course-level total in total_enrl and a per-lab count in enrolled.
+  # Spring totals by design: 201910 = 52, 202010 = 50, 202110 = 47
+  #   → prior-spring avg = (52+50)/2 = 51, current 47, diff = -4, pct = -8 (below).
+  # The XL06 fall rows (202080, total 47) must NOT enter this spring average.
+  # NOTE: 201910 exists ONLY for these two rows — it is not a stable fixture term.
+  "XL0604", 201910L, "XL015", "ANTH","2190C","ANTH 2190C","002",
+  "Forensic Anthropology",           "1","ABQ","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  26L,52L,26L,0L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  TRUE,  FALSE,
+  4.0,4.0, as.Date("2019-01-14"),as.Date("2019-05-11"),
+  "D9","D9","internal",
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2019-01-14"),
+
+  "XL0605", 201910L, "XL016", "ANTH","2190C","ANTH 2190C","003",
+  "Forensic Anthropology",           "1","ABQ","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  26L,52L,26L,0L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  FALSE, FALSE,
+  4.0,4.0, as.Date("2019-01-14"),as.Date("2019-05-11"),
+  "D9","D9","internal",
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2019-01-14"),
+
+  "XL0606", 202010L, "XL017", "ANTH","2190C","ANTH 2190C","002",
+  "Forensic Anthropology",           "1","ABQ","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  25L,50L,26L,1L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  TRUE,  FALSE,
+  4.0,4.0, as.Date("2020-01-13"),as.Date("2020-05-08"),
+  "D9","D9","internal",
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2020-01-13"),
+
+  "XL0607", 202010L, "XL018", "ANTH","2190C","ANTH 2190C","003",
+  "Forensic Anthropology",           "1","ABQ","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  25L,50L,26L,1L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  FALSE, FALSE,
+  4.0,4.0, as.Date("2020-01-13"),as.Date("2020-05-08"),
+  "D9","D9","internal",
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2020-01-13"),
+
+  "XL0608", 202110L, "XL019", "ANTH","2190C","ANTH 2190C","002",
+  "Forensic Anthropology",           "1","ABQ","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  24L,47L,26L,2L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  TRUE,  FALSE,
+  4.0,4.0, as.Date("2021-01-18"),as.Date("2021-05-14"),
+  "D9","D9","internal",
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2021-01-18"),
+
+  "XL0609", 202110L, "XL020", "ANTH","2190C","ANTH 2190C","003",
+  "Forensic Anthropology",           "1","ABQ","SOSC","ANTH",
+  "INS003","Williams, Patricia",
+  23L,47L,26L,3L,
+  "A","ENH","lower","SP",
+  0L,0L,
+  FALSE, FALSE,
+  4.0,4.0, as.Date("2021-01-18"),as.Date("2021-05-14"),
+  "D9","D9","internal",
+  FALSE,NA_character_,NA_character_,
+  TRUE,FALSE,NA_character_,NA_integer_,as.Date("2021-01-18")
 )
 
 # Merge XL sections into the main table. In production, crosslisted sections live

--- a/tests/testthat/test-combined-courses.R
+++ b/tests/testthat/test-combined-courses.R
@@ -20,12 +20,20 @@ context("Combined C-suffix courses")
 # ---------------------------------------------------------------------------
 
 test_that("test fixtures contain combined-course edge cases", {
-  # XL06: ANTH 2190C — crosslisted combined (3 CRNs, 1 primary)
-  anth <- test_sections %>% filter(subject_course == "ANTH 2190C")
+  # XL06: ANTH 2190C fall 202080 — crosslisted combined (3 CRNs, 1 primary).
+  # Scoped to the fall term: XL06-S adds spring pairs of the same course in
+  # 201910/202010/202110 for the dashboard vs-average test (issue #32).
+  anth <- test_sections %>% filter(subject_course == "ANTH 2190C", term == 202080)
   expect_equal(nrow(anth), 3L)
   expect_equal(anth$enrolled, c(16L, 16L, 15L))
   expect_true(all(anth$total_enrl == 47L))
   expect_equal(sum(anth$crosslist_primary), 1L)
+
+  # XL06-S: ANTH 2190C spring pairs — internal crosslist, one primary per term
+  anth_s <- test_sections %>% filter(subject_course == "ANTH 2190C", term != 202080)
+  expect_equal(nrow(anth_s), 6L)
+  expect_true(all(anth_s$crosslist_role == "internal"))
+  expect_equal(sort(unique(anth_s$term)), c(201910, 202010, 202110))
 
   # EC-04: BIOL 2110C — Pattern A non-crosslisted (4 CRNs, XL_ENRL present)
   biol_a <- test_sections %>% filter(subject_course == "BIOL 2110C")

--- a/tests/testthat/test-combined-courses.R
+++ b/tests/testthat/test-combined-courses.R
@@ -29,11 +29,13 @@ test_that("test fixtures contain combined-course edge cases", {
   expect_true(all(anth$total_enrl == 47L))
   expect_equal(sum(anth$crosslist_primary), 1L)
 
-  # XL06-S: ANTH 2190C spring pairs — internal crosslist, one primary per term
+  # XL06-S: ANTH 2190C spring pairs — internal crosslist, one primary per term;
+  # XL06-EA adds a single non-crosslisted EA row in 201910 (campus separation)
   anth_s <- test_sections %>% filter(subject_course == "ANTH 2190C", term != 202080)
-  expect_equal(nrow(anth_s), 6L)
-  expect_true(all(anth_s$crosslist_role == "internal"))
+  expect_equal(nrow(anth_s), 7L)
+  expect_true(all(anth_s$crosslist_role[!is.na(anth_s$crosslist_group)] == "internal"))
   expect_equal(sort(unique(anth_s$term)), c(201910, 202010, 202110))
+  expect_equal(sort(unique(anth_s$campus)), c("ABQ", "EA"))
 
   # EC-04: BIOL 2110C — Pattern A non-crosslisted (4 CRNs, XL_ENRL present)
   biol_a <- test_sections %>% filter(subject_course == "BIOL 2110C")

--- a/tests/testthat/test-crosslist-split.R
+++ b/tests/testthat/test-crosslist-split.R
@@ -38,9 +38,10 @@ test_that("crosslist_group is NA for non-crosslisted sections", {
 test_that("crosslist_group is set to the XL code for crosslisted sections", {
   expect_true(all(!is.na(xl_sections$crosslist_group)))
   # XL01-XL06: external crosslists; 6G+62: internal crosslist groups from EC-06;
-  # E7: internal non-combined group from EC-07 (BIOL 2305)
+  # E7: internal non-combined group from EC-07 (BIOL 2305);
+  # D9: internal combined group from XL06-S (ANTH 2190C springs, issue #32)
   expect_setequal(unique(xl_sections$crosslist_group),
-                  c("XL01", "XL02", "XL03", "XL04", "XL05", "XL06", "6G", "62", "E7"))
+                  c("XL01", "XL02", "XL03", "XL04", "XL05", "XL06", "6G", "62", "E7", "D9"))
 })
 
 test_that("crosslist_group matches crosslist_code for XL sections", {
@@ -56,9 +57,11 @@ test_that("crosslist_primary is TRUE for all non-crosslisted sections", {
   expect_true(all(non_xl$crosslist_primary))
 })
 
-test_that("exactly one section per XL group has crosslist_primary TRUE", {
+test_that("exactly one section per XL group per term has crosslist_primary TRUE", {
+  # Group by term as well: crosslist group codes recur across terms in
+  # production (and in the D9 fixture group), with one primary per offering.
   primary_counts <- xl_sections %>%
-    group_by(crosslist_group) %>%
+    group_by(term, crosslist_group) %>%
     summarize(n_primary = sum(crosslist_primary), .groups = "drop")
 
   expect_true(all(primary_counts$n_primary == 1),
@@ -160,11 +163,12 @@ test_that("total is_split sections = 7 (XL02:2 + XL03:2 + XL05:3)", {
   expect_equal(sum(xl_sections$is_split), 7)
 })
 
-test_that("total non-split XL sections = 16 (XL01:2 + XL04:2 + XL06:3 + EC-06:6 + EC-07:3)", {
+test_that("total non-split XL sections = 22 (XL01:2 + XL04:2 + XL06:3 + XL06-S:6 + EC-06:6 + EC-07:3)", {
   non_split <- xl_sections %>% filter(!is_split)
-  # 7 original (XL01, XL04, XL06) + 6 internal-crosslist C-suffix rows from EC-06
+  # 7 original (XL01, XL04, XL06) + 6 spring ANTH 2190C rows from XL06-S
+  # + 6 internal-crosslist C-suffix rows from EC-06
   # + 3 internal non-combined rows from EC-07 (BIOL 2305)
-  expect_equal(nrow(non_split), 16)
+  expect_equal(nrow(non_split), 22)
   expect_true(all(non_split$level %in% c("upper", "lower")))
 })
 
@@ -197,9 +201,10 @@ test_that("crosslist home filter on XL subset keeps exactly one section per grou
   result <- filter_DESRs(xl_sections, opt)
 
   # External XL groups (XL01-XL06): 1 primary per group = 6 rows
-  # Internal XL groups (6G, 62 from EC-06; E7 from EC-07): all rows kept = 9 rows
-  # Total: 15 rows
-  expect_equal(nrow(result), 15)
+  # Internal XL groups (6G, 62 from EC-06; E7 from EC-07; D9 from XL06-S
+  # across three terms): all rows kept = 9 + 6 = 15 rows
+  # Total: 21 rows
+  expect_equal(nrow(result), 21)
 
   # External groups: only the primary survives
   external <- result %>% filter(crosslist_role != "internal")

--- a/tests/testthat/test-crosslist-split.R
+++ b/tests/testthat/test-crosslist-split.R
@@ -32,7 +32,8 @@ xl_sections <- test_sections %>% filter(!is.na(crosslist_group))
 test_that("crosslist_group is NA for non-crosslisted sections", {
   non_xl <- test_sections %>% filter(is.na(crosslist_group))
   # 71 base + 8 non-crosslisted C-suffix sections (EC-04:4, EC-05:4)
-  expect_equal(nrow(non_xl), 79)
+  # 79 + 1 non-crosslisted XL06-EA row (ANTH 2190C at EA)
+  expect_equal(nrow(non_xl), 80)
 })
 
 test_that("crosslist_group is set to the XL code for crosslisted sections", {

--- a/tests/testthat/test-dept-dashboard-snapshot.R
+++ b/tests/testthat/test-dept-dashboard-snapshot.R
@@ -4,35 +4,47 @@
 # number (total_enrl) and the comparison basis (a single lab CRN's enrolled)
 # came from different columns, and the historical average mixed whole-course
 # totals with single-section counts. get_current_enrl_vs_avg() must compare
-# crosslist-deduplicated course totals on BOTH sides, and the number shown
-# must be the number the diff was computed from.
+# crosslist-deduplicated course totals on BOTH sides, the number shown must
+# be the number the diff was computed from, and campuses must never be
+# merged — each campus compares to its own history.
 #
-# Fixture design (XL06 / XL06-S in designed_test_data.R):
-#   ANTH 2190C springs — 201910 total 52, 202010 total 50, 202110 total 47,
+# Fixture design (XL06 / XL06-S / XL06-EA in designed_test_data.R):
+#   ANTH 2190C ABQ springs — 201910 total 52, 202010 total 50, 202110 total 47,
 #   each term an internal-crosslist pair whose rows carry the course total in
 #   total_enrl and per-lab counts in enrolled.
-#   ANTH 2190C fall — 202080 total 47 (must not enter the spring average).
+#   ANTH 2190C ABQ fall — 202080 total 47 (must not enter the spring average).
+#   ANTH 2190C EA  spring — 201910 total 20 (must not enter the ABQ average).
 
 # The dashboard's exact course_history build (create_dept_dashboard_data).
 build_dashboard_course_history <- function(dept) {
   ch_opt <- list(dept = dept, status = "A", crosslist = "home", uel = TRUE,
-                 group_cols = c("subject_course", "course_title", "term"))
+                 group_cols = c("subject_course", "course_title", "campus", "term"))
   get_enrl(test_sections, ch_opt) %>% dplyr::filter(enrolled > 0)
 }
 
 test_that("course_history reports combined courses at course-level totals, not per-lab counts", {
   ch <- build_dashboard_course_history("ANTH") %>%
-    dplyr::filter(subject_course == "ANTH 2190C") %>%
+    dplyr::filter(subject_course == "ANTH 2190C", campus == "ABQ") %>%
     dplyr::arrange(term)
 
   springs <- ch %>% dplyr::filter(term %in% c(201910, 202010, 202110))
   expect_equal(springs$term, c(201910, 202010, 202110))
-  # Each spring is a 2-CRN internal group: the group total must be counted
+  # Each ABQ spring is a 2-CRN internal group: the group total must be counted
   # once (52/50/47), not per-row (104/100/94) and not one lab's count (26/25/24).
   expect_equal(springs$total_enrl, c(52, 50, 47))
   # For internal groups the home filter keeps all rows, so summed enrolled
   # equals the course total — enrolled and total_enrl must agree.
   expect_equal(springs$enrolled, springs$total_enrl)
+})
+
+test_that("course_history keeps campuses on separate rows", {
+  ch <- build_dashboard_course_history("ANTH") %>%
+    dplyr::filter(subject_course == "ANTH 2190C", term == 201910) %>%
+    dplyr::arrange(campus)
+
+  # One row per campus — 72 on a single merged row would mean campuses merged.
+  expect_equal(ch$campus,     c("ABQ", "EA"))
+  expect_equal(ch$total_enrl, c(52, 20))
 })
 
 test_that("get_current_enrl_vs_avg flags combined courses on deduplicated same-season totals", {
@@ -41,11 +53,14 @@ test_that("get_current_enrl_vs_avg flags combined courses on deduplicated same-s
 
   row <- cmp$below %>% dplyr::filter(subject_course == "ANTH 2190C")
   expect_equal(nrow(row), 1)
+  expect_equal(row$campus, "ABQ")
 
   # The displayed number is the full combined enrollment...
   expect_equal(row$total_enrl, 47)
-  # ...the average is over prior SPRING course totals only: (52 + 50) / 2.
-  # The fall 202080 offering (total 47) must not contaminate the spring average.
+  # ...the average is over prior SPRING course totals at the SAME campus only:
+  # (52 + 50) / 2. The fall 202080 offering (total 47) must not contaminate the
+  # spring average, and the EA 201910 offering (20) must not deflate the ABQ one
+  # (a campus-merged 201910 of 72 would inflate it instead).
   expect_equal(row$hist_avg_enrl, 51)
   expect_equal(row$n_hist, 2)
   # ...and the diff is computed from the same number that is displayed
@@ -58,6 +73,18 @@ test_that("get_current_enrl_vs_avg flags combined courses on deduplicated same-s
   expect_false("ANTH 2190C" %in% cmp$above$subject_course)
 })
 
+test_that("get_current_enrl_vs_avg never merges campuses", {
+  ch <- build_dashboard_course_history("ANTH")
+  cmp <- get_current_enrl_vs_avg(ch, 202110)
+  flagged <- dplyr::bind_rows(cmp$above, cmp$below)
+
+  # EA ran the course only once (201910) and has no current-term offering, so
+  # no EA row can be flagged; the only flagged row is the ABQ one whose average
+  # was proven unaffected by the EA offering above.
+  expect_false("EA" %in% flagged$campus)
+  expect_equal(flagged$campus, "ABQ")
+})
+
 test_that("get_current_enrl_vs_avg requires two prior same-season offerings", {
   ch <- build_dashboard_course_history("ANTH")
   cmp <- get_current_enrl_vs_avg(ch, 202110)
@@ -66,9 +93,21 @@ test_that("get_current_enrl_vs_avg requires two prior same-season offerings", {
   # Everything flagged cleared the n_hist >= 2 gate.
   expect_true(all(flagged$n_hist >= 2))
 
-  # Only ANTH 2190C has rows in 201910, so every other ANTH course current in
-  # 202110 has at most one prior spring and must be excluded. If this fails
-  # after a fixture change, another course now spans >= 3 springs — update
-  # the design notes in designed_test_data.R, not just this expectation.
+  # Only ANTH 2190C at ABQ has rows in 201910, so every other ANTH course
+  # current in 202110 has at most one prior spring and must be excluded. If
+  # this fails after a fixture change, another course now spans >= 3 springs —
+  # update the design notes in designed_test_data.R, not just this expectation.
   expect_equal(flagged$subject_course, "ANTH 2190C")
+})
+
+test_that("snapshot functions stop loudly when campus is missing from history", {
+  # ungroup first: get_enrl returns grouped data, and select(-campus) on a
+  # tibble grouped by campus silently re-adds the column
+  ch_no_campus <- build_dashboard_course_history("ANTH") %>%
+    dplyr::ungroup() %>% dplyr::select(-campus)
+  expect_error(get_current_enrl_vs_avg(ch_no_campus, 202110), "campus")
+  expect_error(get_new_this_term(ch_no_campus, 202110), "campus")
+  expect_error(get_missing_from_earlier(ch_no_campus, 202110), "campus")
+  expect_error(get_repeated_topics_courses(ch_no_campus, 202110), "campus")
+  expect_error(get_enrollment_momentum(ch_no_campus), "campus")
 })

--- a/tests/testthat/test-dept-dashboard-snapshot.R
+++ b/tests/testthat/test-dept-dashboard-snapshot.R
@@ -1,0 +1,74 @@
+# Tests for the Dept Dashboard current-term snapshot functions
+# (R/reports/dept-dashboard.R). Regression coverage for issue #32:
+# ANTH 2190C showed "51 down from an average of 47" because the displayed
+# number (total_enrl) and the comparison basis (a single lab CRN's enrolled)
+# came from different columns, and the historical average mixed whole-course
+# totals with single-section counts. get_current_enrl_vs_avg() must compare
+# crosslist-deduplicated course totals on BOTH sides, and the number shown
+# must be the number the diff was computed from.
+#
+# Fixture design (XL06 / XL06-S in designed_test_data.R):
+#   ANTH 2190C springs — 201910 total 52, 202010 total 50, 202110 total 47,
+#   each term an internal-crosslist pair whose rows carry the course total in
+#   total_enrl and per-lab counts in enrolled.
+#   ANTH 2190C fall — 202080 total 47 (must not enter the spring average).
+
+# The dashboard's exact course_history build (create_dept_dashboard_data).
+build_dashboard_course_history <- function(dept) {
+  ch_opt <- list(dept = dept, status = "A", crosslist = "home", uel = TRUE,
+                 group_cols = c("subject_course", "course_title", "term"))
+  get_enrl(test_sections, ch_opt) %>% dplyr::filter(enrolled > 0)
+}
+
+test_that("course_history reports combined courses at course-level totals, not per-lab counts", {
+  ch <- build_dashboard_course_history("ANTH") %>%
+    dplyr::filter(subject_course == "ANTH 2190C") %>%
+    dplyr::arrange(term)
+
+  springs <- ch %>% dplyr::filter(term %in% c(201910, 202010, 202110))
+  expect_equal(springs$term, c(201910, 202010, 202110))
+  # Each spring is a 2-CRN internal group: the group total must be counted
+  # once (52/50/47), not per-row (104/100/94) and not one lab's count (26/25/24).
+  expect_equal(springs$total_enrl, c(52, 50, 47))
+  # For internal groups the home filter keeps all rows, so summed enrolled
+  # equals the course total — enrolled and total_enrl must agree.
+  expect_equal(springs$enrolled, springs$total_enrl)
+})
+
+test_that("get_current_enrl_vs_avg flags combined courses on deduplicated same-season totals", {
+  ch <- build_dashboard_course_history("ANTH")
+  cmp <- get_current_enrl_vs_avg(ch, 202110)
+
+  row <- cmp$below %>% dplyr::filter(subject_course == "ANTH 2190C")
+  expect_equal(nrow(row), 1)
+
+  # The displayed number is the full combined enrollment...
+  expect_equal(row$total_enrl, 47)
+  # ...the average is over prior SPRING course totals only: (52 + 50) / 2.
+  # The fall 202080 offering (total 47) must not contaminate the spring average.
+  expect_equal(row$hist_avg_enrl, 51)
+  expect_equal(row$n_hist, 2)
+  # ...and the diff is computed from the same number that is displayed
+  # (the issue #32 failure showed total 51 while diffing a lab CRN's 17).
+  expect_equal(row$diff, -4L)
+  expect_equal(row$diff, as.integer(round(row$total_enrl - row$hist_avg_enrl)))
+  expect_equal(row$pct_diff, -8L)
+
+  # A below-average course must not also appear as above-average.
+  expect_false("ANTH 2190C" %in% cmp$above$subject_course)
+})
+
+test_that("get_current_enrl_vs_avg requires two prior same-season offerings", {
+  ch <- build_dashboard_course_history("ANTH")
+  cmp <- get_current_enrl_vs_avg(ch, 202110)
+  flagged <- dplyr::bind_rows(cmp$above, cmp$below)
+
+  # Everything flagged cleared the n_hist >= 2 gate.
+  expect_true(all(flagged$n_hist >= 2))
+
+  # Only ANTH 2190C has rows in 201910, so every other ANTH course current in
+  # 202110 has at most one prior spring and must be excluded. If this fails
+  # after a fixture change, another course now spans >= 3 springs — update
+  # the design notes in designed_test_data.R, not just this expectation.
+  expect_equal(flagged$subject_course, "ANTH 2190C")
+})

--- a/tests/testthat/test-enrollment.R
+++ b/tests/testthat/test-enrollment.R
@@ -35,13 +35,14 @@ test_that("summarize_courses returns correct structure", {
   expect_true("waiting"      %in% names(result))
 })
 
-test_that("summarize_courses grouped by term returns 4 rows (one per term)", {
+test_that("summarize_courses grouped by term returns 5 rows (one per term)", {
   active <- test_sections %>% filter(status == "A")
   opt    <- list(group_cols = c("term"))
   result <- summarize_courses(active, opt)
 
-  expect_equal(nrow(result), 4)
-  expect_setequal(result$term, c(202010, 202060, 202080, 202110))
+  # 201910 exists only for the XL06-S ANTH 2190C spring-history rows (issue #32)
+  expect_equal(nrow(result), 5)
+  expect_setequal(result$term, c(201910, 202010, 202060, 202080, 202110))
 })
 
 test_that("summarize_courses enrolled totals match fixture per term", {
@@ -51,8 +52,10 @@ test_that("summarize_courses enrolled totals match fixture per term", {
 
   # 202080 (Fall 2020): 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) + EC-07:3 = 35
   # enrolled for 202080: 370 base + 89 (EC-04) + 89 (EC-05) + 230 (EC-06) + 71 (EC-07) = 849
-  expect_equal(result$sections, c(28, 12, 35, 17))
-  expect_equal(result$enrolled, c(462, 217, 849, 344))
+  # XL06-S (ANTH 2190C springs): 201910 = 2 rows / 52 enrolled;
+  # 202010 += 2 rows / 50 enrolled; 202110 += 2 rows / 47 enrolled
+  expect_equal(result$sections, c(2, 30, 12, 35, 19))
+  expect_equal(result$enrolled, c(52, 512, 217, 849, 391))
 })
 
 test_that("summarize_courses xl_sections and reg_sections sum to sections", {
@@ -60,8 +63,8 @@ test_that("summarize_courses xl_sections and reg_sections sum to sections", {
   opt    <- list(group_cols = c("term"))
   result <- summarize_courses(active, opt)
 
-  # 202010 active: 11 XL sections, 17 regular
-  expect_equal(result$xl_sections,  11)
+  # 202010 active: 11 XL sections + 2 XL06-S rows = 13, 17 regular
+  expect_equal(result$xl_sections,  13)
   expect_equal(result$reg_sections, 17)
   expect_equal(result$xl_sections + result$reg_sections, result$sections)
 })
@@ -133,15 +136,16 @@ test_that("get_enrl returns correct structure", {
   expect_true("sections"  %in% names(result))
 })
 
-test_that("get_enrl aggregated by term returns 4 rows with correct totals", {
+test_that("get_enrl aggregated by term returns 5 rows with correct totals", {
   opt    <- list(status = "A", group_cols = c("term"), uel = FALSE)
   result <- get_enrl(test_sections, opt) %>% arrange(term)
 
-  expect_equal(nrow(result), 4)
+  expect_equal(nrow(result), 5)
   # 202080: 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) + EC-07:3 = 35
   # enrolled: 370+89+89+230+71 (EC-07) = 849
-  expect_equal(result$sections, c(28, 12, 35, 17))
-  expect_equal(result$enrolled, c(462, 217, 849, 344))
+  # XL06-S springs: 201910 = 2 rows / 52; 202010 += 2 / 50; 202110 += 2 / 47
+  expect_equal(result$sections, c(2, 30, 12, 35, 19))
+  expect_equal(result$enrolled, c(52, 512, 217, 849, 391))
 })
 
 test_that("get_enrl filters by department correctly", {
@@ -168,8 +172,8 @@ test_that("get_enrl without group_cols returns section-level data", {
   opt    <- list(term = 202010, status = "A", uel = FALSE)
   result <- get_enrl(test_sections, opt)
 
-  # Section-level: 28 active sections in 202010
-  expect_equal(nrow(result), 28)
+  # Section-level: 28 active sections in 202010 + 2 XL06-S rows = 30
+  expect_equal(nrow(result), 30)
   expect_true("crn"           %in% names(result))
   expect_true("subject_course" %in% names(result))
 })
@@ -205,7 +209,7 @@ test_that("get_enrl handles multiple terms correctly", {
   result <- get_enrl(test_sections, opt) %>% arrange(term)
 
   expect_equal(nrow(result), 2)
-  expect_equal(result$sections, c(28, 12))
+  expect_equal(result$sections, c(30, 12))
 })
 
 

--- a/tests/testthat/test-enrollment.R
+++ b/tests/testthat/test-enrollment.R
@@ -52,10 +52,10 @@ test_that("summarize_courses enrolled totals match fixture per term", {
 
   # 202080 (Fall 2020): 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) + EC-07:3 = 35
   # enrolled for 202080: 370 base + 89 (EC-04) + 89 (EC-05) + 230 (EC-06) + 71 (EC-07) = 849
-  # XL06-S (ANTH 2190C springs): 201910 = 2 rows / 52 enrolled;
+  # XL06-S (ANTH 2190C springs): 201910 = 2 ABQ rows / 52 + 1 EA row / 20;
   # 202010 += 2 rows / 50 enrolled; 202110 += 2 rows / 47 enrolled
-  expect_equal(result$sections, c(2, 30, 12, 35, 19))
-  expect_equal(result$enrolled, c(52, 512, 217, 849, 391))
+  expect_equal(result$sections, c(3, 30, 12, 35, 19))
+  expect_equal(result$enrolled, c(72, 512, 217, 849, 391))
 })
 
 test_that("summarize_courses xl_sections and reg_sections sum to sections", {
@@ -143,9 +143,9 @@ test_that("get_enrl aggregated by term returns 5 rows with correct totals", {
   expect_equal(nrow(result), 5)
   # 202080: 18 base + 14 C-suffix (EC-04:4, EC-05:4, EC-06:6) + EC-07:3 = 35
   # enrolled: 370+89+89+230+71 (EC-07) = 849
-  # XL06-S springs: 201910 = 2 rows / 52; 202010 += 2 / 50; 202110 += 2 / 47
-  expect_equal(result$sections, c(2, 30, 12, 35, 19))
-  expect_equal(result$enrolled, c(52, 512, 217, 849, 391))
+  # XL06-S springs: 201910 = 2 ABQ / 52 + 1 EA / 20; 202010 += 2 / 50; 202110 += 2 / 47
+  expect_equal(result$sections, c(3, 30, 12, 35, 19))
+  expect_equal(result$enrolled, c(72, 512, 217, 849, 391))
 })
 
 test_that("get_enrl filters by department correctly", {

--- a/tests/testthat/test-filtering.R
+++ b/tests/testthat/test-filtering.R
@@ -57,8 +57,8 @@ test_that("filter_DESRs filters by ANTH department correctly", {
   opt <- make_opt(dept = "ANTH")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 12 pre-XL06-S + 6 ANTH 2190C spring rows = 18
-  expect_equal(nrow(filtered), 18)
+  # 12 pre-XL06-S + 6 ANTH 2190C spring rows + 1 XL06-EA row = 19
+  expect_equal(nrow(filtered), 19)
   expect_true(all(filtered$department == "ANTH"))
 })
 
@@ -124,7 +124,8 @@ test_that("filter_DESRs filters by EA campus correctly", {
   opt <- make_opt(course_campus = "EA")
   filtered <- filter_DESRs(test_sections, opt)
 
-  expect_equal(nrow(filtered), 7)
+  # 7 base + 1 XL06-EA row (ANTH 2190C at EA)
+  expect_equal(nrow(filtered), 8)
   expect_true(all(filtered$campus == "EA"))
 })
 
@@ -144,8 +145,8 @@ test_that("filter_DESRs filters by active status explicitly", {
   opt <- make_opt(status = "A")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all status="A") = 98
-  expect_equal(nrow(filtered), 98)
+  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S + 1 XL06-EA (all status="A") = 99
+  expect_equal(nrow(filtered), 99)
   expect_true(all(filtered$status == "A"))
 })
 
@@ -173,8 +174,8 @@ test_that("filter_DESRs filters by ENH delivery correctly", {
   opt <- make_opt(im = "ENH")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 46 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all delivery="ENH") = 69
-  expect_equal(nrow(filtered), 69)
+  # 46 base + 14 C-suffix + 3 EC-07 + 6 XL06-S + 1 XL06-EA (all delivery="ENH") = 70
+  expect_equal(nrow(filtered), 70)
   expect_true(all(filtered$delivery_method == "ENH"))
 })
 
@@ -194,8 +195,8 @@ test_that("filter_DESRs filters by full term (1) correctly", {
   opt <- make_opt(pt = "1")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 59 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all part_term="1") = 82
-  expect_equal(nrow(filtered), 82)
+  # 59 base + 14 C-suffix + 3 EC-07 + 6 XL06-S + 1 XL06-EA (all part_term="1") = 83
+  expect_equal(nrow(filtered), 83)
   expect_true(all(filtered$part_term == "1"))
 })
 
@@ -231,8 +232,8 @@ test_that("filter_DESRs filters by lower level correctly", {
   opt <- make_opt(level = "lower")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 49 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all level="lower") = 72
-  expect_equal(nrow(filtered), 72)
+  # 49 base + 14 C-suffix + 3 EC-07 + 6 XL06-S + 1 XL06-EA (all level="lower") = 73
+  expect_equal(nrow(filtered), 73)
   expect_true(all(filtered$level == "lower"))
 })
 
@@ -359,8 +360,8 @@ test_that("filter_by_term handles 'spring' keyword", {
   # Spring = terms ending in 10: 202010 + 202110
   filtered <- filter_by_term(test_sections, "spring", "term")
 
-  # 50 pre-XL06-S + 6 ANTH 2190C spring rows (201910/202010/202110) = 56
-  expect_equal(nrow(filtered), 56)
+  # 50 pre-XL06-S + 6 ANTH 2190C spring rows + 1 XL06-EA (all springs) = 57
+  expect_equal(nrow(filtered), 57)
   expect_true(all(substring(as.character(filtered$term), 5, 6) == "10"))
 })
 

--- a/tests/testthat/test-filtering.R
+++ b/tests/testthat/test-filtering.R
@@ -57,7 +57,8 @@ test_that("filter_DESRs filters by ANTH department correctly", {
   opt <- make_opt(dept = "ANTH")
   filtered <- filter_DESRs(test_sections, opt)
 
-  expect_equal(nrow(filtered), 12)
+  # 12 pre-XL06-S + 6 ANTH 2190C spring rows = 18
+  expect_equal(nrow(filtered), 18)
   expect_true(all(filtered$department == "ANTH"))
 })
 
@@ -77,7 +78,7 @@ test_that("filter_DESRs filters by term 202010 correctly", {
   opt <- make_opt(term = 202010)
   filtered <- filter_DESRs(test_sections, opt)
 
-  expect_equal(nrow(filtered), 28)
+  expect_equal(nrow(filtered), 30)
   expect_true(all(filtered$term == 202010))
 })
 
@@ -102,7 +103,7 @@ test_that("filter_DESRs filters by term 202110 correctly", {
   opt <- make_opt(term = 202110)
   filtered <- filter_DESRs(test_sections, opt)
 
-  expect_equal(nrow(filtered), 17)
+  expect_equal(nrow(filtered), 19)
   expect_true(all(filtered$term == 202110))
 })
 
@@ -114,8 +115,8 @@ test_that("filter_DESRs filters by ABQ campus correctly", {
   opt <- make_opt(course_campus = "ABQ")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 67 base + 14 C-suffix + 3 EC-07 rows (all ABQ campus) = 84
-  expect_equal(nrow(filtered), 84)
+  # 67 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all ABQ campus) = 90
+  expect_equal(nrow(filtered), 90)
   expect_true(all(filtered$campus == "ABQ"))
 })
 
@@ -143,8 +144,8 @@ test_that("filter_DESRs filters by active status explicitly", {
   opt <- make_opt(status = "A")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 75 base + 14 C-suffix + 3 EC-07 rows (all status="A") = 92
-  expect_equal(nrow(filtered), 92)
+  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all status="A") = 98
+  expect_equal(nrow(filtered), 98)
   expect_true(all(filtered$status == "A"))
 })
 
@@ -172,8 +173,8 @@ test_that("filter_DESRs filters by ENH delivery correctly", {
   opt <- make_opt(im = "ENH")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 46 base + 14 C-suffix + 3 EC-07 rows (all delivery="ENH") = 63
-  expect_equal(nrow(filtered), 63)
+  # 46 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all delivery="ENH") = 69
+  expect_equal(nrow(filtered), 69)
   expect_true(all(filtered$delivery_method == "ENH"))
 })
 
@@ -193,8 +194,8 @@ test_that("filter_DESRs filters by full term (1) correctly", {
   opt <- make_opt(pt = "1")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 59 base + 14 C-suffix + 3 EC-07 rows (all part_term="1") = 76
-  expect_equal(nrow(filtered), 76)
+  # 59 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all part_term="1") = 82
+  expect_equal(nrow(filtered), 82)
   expect_true(all(filtered$part_term == "1"))
 })
 
@@ -230,8 +231,8 @@ test_that("filter_DESRs filters by lower level correctly", {
   opt <- make_opt(level = "lower")
   filtered <- filter_DESRs(test_sections, opt)
 
-  # 49 base + 14 C-suffix + 3 EC-07 rows (all level="lower") = 66
-  expect_equal(nrow(filtered), 66)
+  # 49 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all level="lower") = 72
+  expect_equal(nrow(filtered), 72)
   expect_true(all(filtered$level == "lower"))
 })
 
@@ -339,25 +340,27 @@ test_that("filter_by_col errors on missing column", {
 })
 
 test_that("filter_by_term handles term range correctly", {
-  # 202010 (30 all-status) + 202060 (14) = 44
+  # 202010 (32 all-status incl. 2 XL06-S) + 202060 (14) = 46
   filtered <- filter_by_term(test_sections, "202010-202060", "term")
 
-  expect_equal(nrow(filtered), 44)
+  expect_equal(nrow(filtered), 46)
   expect_true(all(filtered$term %in% c(202010, 202060)))
 })
 
 test_that("filter_by_term covers all terms in fixture range", {
-  # All 4 test terms = all 102 rows (85 base + 14 C-suffix + 3 EC-07)
+  # The 4 stable terms = 106 rows (85 base + 14 C-suffix + 3 EC-07 + 4 XL06-S
+  # in 202010/202110); the 2 XL06-S rows in 201910 fall outside the range
   filtered <- filter_by_term(test_sections, "202010-202110", "term")
 
-  expect_equal(nrow(filtered), 102)
+  expect_equal(nrow(filtered), 106)
 })
 
 test_that("filter_by_term handles 'spring' keyword", {
   # Spring = terms ending in 10: 202010 + 202110
   filtered <- filter_by_term(test_sections, "spring", "term")
 
-  expect_equal(nrow(filtered), 50)
+  # 50 pre-XL06-S + 6 ANTH 2190C spring rows (201910/202010/202110) = 56
+  expect_equal(nrow(filtered), 56)
   expect_true(all(substring(as.character(filtered$term), 5, 6) == "10"))
 })
 

--- a/tests/testthat/test-low-enrollment.R
+++ b/tests/testthat/test-low-enrollment.R
@@ -25,8 +25,8 @@ test_that("filtering to status=A excludes cancelled sections", {
 
   expect_true(all(active$status    == "A"))
   expect_true(all(cancelled$status != "A"))
-  # 75 base + 14 C-suffix + 3 EC-07 rows (all status="A") = 92
-  expect_equal(nrow(active), 92)
+  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all status="A") = 98
+  expect_equal(nrow(active), 98)
 })
 
 test_that("active sections include the zero-enrollment edge case", {
@@ -63,8 +63,8 @@ test_that("threshold filter with very high max returns all active sections", {
   all_active <- test_sections %>%
     filter(status == "A", total_enrl >= 0, total_enrl <= 9999)
 
-  # 75 base + 14 C-suffix + 3 EC-07 rows = 92
-  expect_equal(nrow(all_active), 92)
+  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows = 98
+  expect_equal(nrow(all_active), 98)
 })
 
 test_that("threshold filter that matches nothing returns zero rows", {

--- a/tests/testthat/test-low-enrollment.R
+++ b/tests/testthat/test-low-enrollment.R
@@ -25,8 +25,8 @@ test_that("filtering to status=A excludes cancelled sections", {
 
   expect_true(all(active$status    == "A"))
   expect_true(all(cancelled$status != "A"))
-  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows (all status="A") = 98
-  expect_equal(nrow(active), 98)
+  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S + 1 XL06-EA (all status="A") = 99
+  expect_equal(nrow(active), 99)
 })
 
 test_that("active sections include the zero-enrollment edge case", {
@@ -63,8 +63,8 @@ test_that("threshold filter with very high max returns all active sections", {
   all_active <- test_sections %>%
     filter(status == "A", total_enrl >= 0, total_enrl <= 9999)
 
-  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S rows = 98
-  expect_equal(nrow(all_active), 98)
+  # 75 base + 14 C-suffix + 3 EC-07 + 6 XL06-S + 1 XL06-EA = 99
+  expect_equal(nrow(all_active), 99)
 })
 
 test_that("threshold filter that matches nothing returns zero rows", {

--- a/tests/testthat/test-summary-functions.R
+++ b/tests/testthat/test-summary-functions.R
@@ -108,10 +108,19 @@ test_that("course_enrl uses total_enrl (correct for combined C-suffix courses)",
   # After deduplication, course_enrl should be 47, not 16
   result <- get_course_section_counts(test_sections)
 
-  anth_2190c <- result %>% dplyr::filter(subject_course == "ANTH 2190C")
+  # Fall 202080 (XL06): home/partner group, only the primary survives the filter
+  anth_2190c <- result %>% dplyr::filter(subject_course == "ANTH 2190C", term == 202080)
   expect_equal(nrow(anth_2190c), 1)
   expect_equal(anth_2190c$course_enrl, 47L)
   expect_equal(anth_2190c$n_sections,  1L)
+
+  # Springs (XL06-S): internal pairs, both rows kept, group total counted once
+  anth_springs <- result %>%
+    dplyr::filter(subject_course == "ANTH 2190C", term != 202080) %>%
+    dplyr::arrange(term)
+  expect_equal(anth_springs$term,        c(201910L, 202010L, 202110L))
+  expect_equal(anth_springs$course_enrl, c(52L, 50L, 47L))
+  expect_equal(anth_springs$n_sections,  c(2L, 2L, 2L))
 })
 
 test_that("course_enrl counts a multi-CRN internal group once (EC-07 / BIOL 2305)", {
@@ -319,9 +328,12 @@ test_that("excludes crosslist partner rows from counts", {
   hist_courses <- test_sections %>%
     dplyr::filter(subject == "HIST", term == 202010L, status == "A",
                   is.na(crosslist_group) | crosslist_primary == TRUE)
+  # Home-filter semantics: external groups keep only the home/primary row,
+  # internal groups (XL06-S D9 pair) keep ALL rows — both lab CRNs are real
+  # ANTH sections, so primary-only would undercount them.
   anth_courses <- test_sections %>%
     dplyr::filter(subject == "ANTH", term == 202010L, status == "A",
-                  is.na(crosslist_group) | crosslist_primary == TRUE)
+                  is.na(crosslist_group) | crosslist_role %in% c("home", "internal"))
 
   expect_equal(hist_stats$n_sections, nrow(hist_courses))
   expect_equal(anth_stats$n_sections, nrow(anth_courses))

--- a/tests/testthat/test-summary-functions.R
+++ b/tests/testthat/test-summary-functions.R
@@ -114,13 +114,15 @@ test_that("course_enrl uses total_enrl (correct for combined C-suffix courses)",
   expect_equal(anth_2190c$course_enrl, 47L)
   expect_equal(anth_2190c$n_sections,  1L)
 
-  # Springs (XL06-S): internal pairs, both rows kept, group total counted once
+  # Springs (XL06-S + XL06-EA): internal pairs, both rows kept, group total
+  # counted once; campuses stay on separate rows (never merged)
   anth_springs <- result %>%
     dplyr::filter(subject_course == "ANTH 2190C", term != 202080) %>%
-    dplyr::arrange(term)
-  expect_equal(anth_springs$term,        c(201910L, 202010L, 202110L))
-  expect_equal(anth_springs$course_enrl, c(52L, 50L, 47L))
-  expect_equal(anth_springs$n_sections,  c(2L, 2L, 2L))
+    dplyr::arrange(term, campus)
+  expect_equal(anth_springs$term,        c(201910L, 201910L, 202010L, 202110L))
+  expect_equal(anth_springs$campus,      c("ABQ", "EA", "ABQ", "ABQ"))
+  expect_equal(anth_springs$course_enrl, c(52L, 20L, 50L, 47L))
+  expect_equal(anth_springs$n_sections,  c(2L, 1L, 2L, 2L))
 })
 
 test_that("course_enrl counts a multi-CRN internal group once (EC-07 / BIOL 2305)", {


### PR DESCRIPTION
Closes out #32 (ANTH 2190C "51 down from an average of 47"): reproduces and explains the original bug, pins the already-landed fix with regression tests, and — as a follow-up the investigation surfaced — makes campus merging impossible in dashboard course history and Enrollment trends.

## Commit 1 — reproduce, explain, and pin the #32 bug

Running the **April 2026 code** (the version Keith saw) in a worktree against current data reproduces his report exactly — `hist_avg_enrl = 46.7`, displayed total 51, flagged "below":

1. **The displayed number and the compared number came from different columns.** The dashboard label showed `total_enrl` (51 = the real combined enrollment), but `get_current_enrl_vs_avg()` diffed `enrolled` — which, after the then-current crosslist dedup, held a **single lab CRN's count (17)** for this internal-crosslist combined course.
2. **The historical average mixed units.** Pre-2022 springs (before the course was crosslisted) contributed whole-course totals (116, 58, 54); post-2022 springs contributed single-lab counts (17, 18, 17). Mean = 46.7 → "the average of 47" that couldn't be derived from any visible numbers.

So "51 down from 47" was really "17 down from 46.7" wearing a 51 label. The fix already landed in two earlier changes — `a186eba` (May: comparison uses `total_enrl` on both sides) and #50 (July: crosslist groups counted once in aggregated `total_enrl`) — but nothing pinned it. This commit adds:

- **XL06-S fixture rows**: ANTH 2190C internal-crosslist pairs across three springs (201910 = 52, 202010 = 50, 202110 = 47) so the vs-average comparison has a same-season history. Designed arithmetic: prior-spring avg 51, diff −4, pct −8.
- **`test-dept-dashboard-snapshot.R`** (first coverage for the dashboard snapshot functions): combined courses at course-level totals, displayed number = diff basis, same-season-only averaging, `n_hist >= 2` gate.
- Extended `get_course_section_counts()` pins and a corrected `get_subject_current_stats()` test reference filter (internal groups keep all rows).

## Commit 2 — campuses are never merged

With no campus filter, course history grouped only by (course, term), so multi-campus courses had campus enrollments **summed into one row** — real ANTH 2190C Spring 2020 showed 116 (ABQ 56 + EA 60), inflating its own historical average. Now:

- The dashboard history build (`create_dept_dashboard_data`) and the Enrollment-page trends build carry **campus in group_cols** — one history row per course per campus per term.
- Every consumer — `get_current_enrl_vs_avg`, `get_new_this_term`, `get_missing_from_earlier`, `get_repeated_topics_courses`, `get_enrollment_momentum`, `get_new_courses`, `get_dormant_courses`, `.recent_history_str` — groups and joins per campus, and **stops loudly** (`.assert_history_has_campus`) if the campus column is missing. Newness in `get_new_this_term` stays course-level (a course that ever ran at any campus is not "new"), but enrollment is always reported per campus.
- Dashboard rows are tagged with the campus when a table spans more than one campus; the Enrollment trend plot draws one line per campus instead of summing them.
- **XL06-EA fixture row** (ANTH 2190C at EA, 201910, enrolled 20) proves the ABQ spring average stays (52+50)/2 = 51 rather than absorbing the EA offering, plus a dedicated never-merged test and loud-failure tests for all consumers.

## Verification

- Full test suite: **FAIL 0 | PASS 1803**.
- Against production data: ANTH 2190C history is one row per campus (Spring 2020 = ABQ 56 + EA 60, no 116), the spring comparison is ABQ-only (avg 53.2 vs current 50, an honest −6%), and the full ANTH dashboard build runs end to end.
- Issue #32 is closed with the explanation comment.

## Notes for review

- All fixture count-pin updates carry arithmetic comments per house style.
- Gotcha discovered while testing: `select(-campus)` on data grouped by campus silently re-adds the column — the missing-campus tests `ungroup()` first, and both history builds now `ungroup()` after `get_enrl()` per the AGENTS.md dplyr rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
