### PR TITLE
Center loading overlays via shared class (fixes waitlist)

### DIFF
--- a/R/modules/ui-helpers.R
+++ b/R/modules/ui-helpers.R
@@ -187,6 +187,7 @@ cedar_loading_overlay <- function(id, run_button, ..., emoji = "\U0001f332",
     class = "loader-anchor",
     div(
       id = paste0(id, "-loading-overlay"),
+      class = "dash-loader-overlay",
       style = "display: none;",
       div(class = "dash-loader-backdrop"),
       div(class = "dash-loader-box",

--- a/ui.R
+++ b/ui.R
@@ -564,6 +564,7 @@ nav_panel(
   # Loading overlay — shown while dashboard data is computing
   div(
     id = "dashboard-loading-overlay",
+    class = "dash-loader-overlay",
     style = "display: none;",
     div(class = "dash-loader-backdrop"),
     div(class = "dash-loader-box",
@@ -1013,6 +1014,7 @@ nav_panel(
 
       div(
         id = "enrl-loading-overlay",
+        class = "dash-loader-overlay",
         style = "display: none;",
         div(class = "dash-loader-backdrop"),
         div(class = "dash-loader-box",

--- a/www/cedar-custom.css
+++ b/www/cedar-custom.css
@@ -1724,12 +1724,10 @@ details.cedar-detail-panel .panel-body p {
 #rs_tabs .nav-link    { font-size: 0.95rem; }
 
 /* ── Loading overlays ─────────────────────────────────────────────────────── */
-#dashboard-loading-overlay,
-#regstats-loading-overlay,
-#enrl-loading-overlay,
-#seatfinder-loading-overlay,
-#cancellations-loading-overlay,
-#headcount-loading-overlay {
+/* One rule centers every module's overlay. cedar_loading_overlay() tags the
+   overlay div with .dash-loader-overlay, so new modules are centered by default
+   without adding a per-id selector here. */
+.dash-loader-overlay {
   position: fixed;
   inset: 0;
   z-index: 1000;


### PR DESCRIPTION
## Problem

The waitlist loading overlay (spinner + emoji + "Loading…" message) rendered in the **top-left corner** instead of centered.

## Root cause

The overlay's centering came from a CSS rule targeting a **hardcoded list of six overlay ids**:

```css
#dashboard-loading-overlay, #regstats-loading-overlay, #enrl-loading-overlay,
#seatfinder-loading-overlay, #cancellations-loading-overlay, #headcount-loading-overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; }
```

`#waitlist-loading-overlay` was never added to that list, so the waitlist overlay got no positioning and fell to the top-left. This enumerated-id pattern is fragile — every new module has to be added by hand or it breaks.

## Fix

Replace the id-list selector with a single `.dash-loader-overlay` class rule, and tag every overlay with that class:

- `cedar_loading_overlay()` now adds `class = "dash-loader-overlay"`, covering **regstats, seatfinder, cancellations, headcount, and waitlist** automatically.
- The **dashboard** and **enrollment** overlays are built inline in `ui.R` (not via the helper), so the class was added to those two divs as well.

Positioning properties are unchanged from the old id rule — this only moves them from per-id to a shared class. New modules built with the helper are now centered by default, with no per-id CSS to maintain.

## Verification

Rendered the real overlay markup against the actual `www/cedar-custom.css` in headless Chrome, toggling only the class:

- **Without** the class (waitlist's actual state): loader box pinned to the top-left — reproduces the reported bug.
- **With** `.dash-loader-overlay`: loader box centered horizontally and vertically.

All seven overlays now share the class and center from the one rule. `R` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)