### PR TITLE
Convert dashboard & enrollment to cedar_loading_overlay()

### DIFF
--- a/R/modules/ui-helpers.R
+++ b/R/modules/ui-helpers.R
@@ -158,6 +158,14 @@ cedar_pot_coldef <- function(name = "PoT", maxWidth = 52, align = "center") {
 #   run_button   run button's id relative to the module (e.g. "cn_button"); the
 #                overlay shows on a capture-phase click of "#<id>-<run_button>",
 #                which also catches the programmatic btn.click() from URL autorun.
+#   trigger_input  alternative to run_button for non-module tabs (dashboard,
+#                  enrollment): a Shiny input name watched via shiny:inputchanged.
+#                  The overlay shows when that input changes — use it when the run
+#                  signal is a select or actionButton whose DOM id is not
+#                  namespaced as "<id>-<run_button>". Supply exactly one of
+#                  run_button / trigger_input.
+#   hide_on_empty  with trigger_input, also hide the overlay when the watched
+#                  input clears to empty (e.g. deselecting a dashboard department).
 #   ...            the tab body placed under the overlay (typically a uiOutput()).
 #   emoji          glyph shown over the spinner (defaults to the cedar tree).
 #   report_type    optional timing-log key; when given, fresh/cached estimates are
@@ -171,9 +179,13 @@ cedar_pot_coldef <- function(name = "PoT", maxWidth = 52, align = "center") {
 # "Loading… (est. Fs)"; with neither, plain "Loading…". On completion the server
 # passes `cached` (see signal_load_complete) so the timing line names which path
 # ran: "Loaded from cache in Ns" / "Generated in Ns" / "Loaded in Ns".
-cedar_loading_overlay <- function(id, run_button, ..., emoji = "\U0001f332",
+cedar_loading_overlay <- function(id, run_button = NULL, ..., emoji = "\U0001f332",
+                                  trigger_input = NULL, hide_on_empty = FALSE,
                                   report_type = NULL, fresh_default = NULL,
                                   cached_default = NULL) {
+  if (is.null(run_button) && is.null(trigger_input)) {
+    stop("cedar_loading_overlay(): supply run_button (click trigger) or trigger_input (input-change trigger).")
+  }
   fresh_sec <- fresh_default
   cached_sec <- cached_default
   if (!is.null(report_type)) {
@@ -183,6 +195,9 @@ cedar_loading_overlay <- function(id, run_button, ..., emoji = "\U0001f332",
   }
   expected_js <- if (is.null(fresh_sec))  "null" else as.integer(fresh_sec)
   cached_js   <- if (is.null(cached_sec)) "null" else as.integer(cached_sec)
+  runbtn_js   <- if (is.null(run_button))    "" else run_button
+  trigger_js  <- if (is.null(trigger_input)) "" else trigger_input
+  hide_js     <- if (isTRUE(hide_on_empty))  "true" else "false"
   div(
     class = "loader-anchor",
     div(
@@ -201,15 +216,29 @@ cedar_loading_overlay <- function(id, run_button, ..., emoji = "\U0001f332",
     ),
     tags$script(HTML(sprintf(
 '(function() {
-  var PREFIX = "%s", RUNBTN = "%s", EXPECTED = %s, CACHED = %s;
+  var PREFIX = "%s", RUNBTN = "%s", TRIGGER = "%s", HIDE_EMPTY = %s, EXPECTED = %s, CACHED = %s;
   var hideTimer = null;
   function el(suffix) { return document.getElementById(PREFIX + suffix); }
 
-  // Capture-phase click so it fires for real clicks AND the programmatic
-  // btn.click() dispatched by URL autorun / cross-tab navigation.
-  document.addEventListener("click", function(e) {
-    if (e.target && e.target.closest && e.target.closest("#" + PREFIX + "-" + RUNBTN)) showOverlay();
-  }, true);
+  if (TRIGGER) {
+    // Input-change trigger for non-module tabs whose run signal is a select or
+    // actionButton input (no namespaced run button to click).
+    $(document).on("shiny:inputchanged", function(e) {
+      if (e.name !== TRIGGER) return;
+      if (HIDE_EMPTY) {
+        if (e.value !== null && e.value !== undefined && e.value !== "") showOverlay();
+        else hideOverlay();
+      } else {
+        showOverlay();
+      }
+    });
+  } else {
+    // Capture-phase click so it fires for real clicks AND the programmatic
+    // btn.click() dispatched by URL autorun / cross-tab navigation.
+    document.addEventListener("click", function(e) {
+      if (e.target && e.target.closest && e.target.closest("#" + PREFIX + "-" + RUNBTN)) showOverlay();
+    }, true);
+  }
 
   Shiny.addCustomMessageHandler(PREFIX + "_load_complete", function(msg) { completeOverlay(msg || {}); });
 
@@ -245,6 +274,15 @@ cedar_loading_overlay <- function(id, run_button, ..., emoji = "\U0001f332",
     fadeOut(800);
   }
 
+  function hideOverlay() {
+    clearTimeout(hideTimer);
+    var box = el("-loading-overlay");
+    if (!box) return;
+    box.style.transition = "";
+    box.style.opacity = "1";
+    box.style.display = "none";
+  }
+
   function fadeOut(delay) {
     var box = el("-loading-overlay");
     hideTimer = setTimeout(function() {
@@ -258,7 +296,7 @@ cedar_loading_overlay <- function(id, run_button, ..., emoji = "\U0001f332",
     }, delay);
   }
 })();',
-      id, run_button, expected_js, cached_js
+      id, runbtn_js, trigger_js, hide_js, expected_js, cached_js
     ))),
     ...
   )

--- a/server.R
+++ b/server.R
@@ -418,11 +418,7 @@ enrl_data <- eventReactive(input$enrl_button, {
   }
 
   duration_sec <- end_report_timer(timer)
-  avg_sec <- get_average_report_time("enrollment")
-  session$sendCustomMessage("enrl_load_complete", list(
-    duration_sec = round(duration_sec, 1),
-    avg_sec      = if (!is.null(avg_sec)) round(avg_sec, 1) else NULL
-  ))
+  signal_load_complete(session, "enrl", duration_sec = duration_sec)
 
   list(data = data, cl_data = cl_data, opt = opt, filter_warning = filter_warning)
 }, ignoreNULL = TRUE, ignoreInit = TRUE)
@@ -3517,7 +3513,6 @@ output$enrl_summary_download <- downloadHandler(
     log_data_filter(session, "dashboard_dept", dept)
     dashboard_data(NULL)
 
-    avg <- get_average_report_time("dept_dashboard")
     timer <- start_report_timer("dept_dashboard", list(dept = dept))
 
     tryCatch({
@@ -3529,12 +3524,10 @@ output$enrl_summary_download <- downloadHandler(
       # diagnose_new_this_term(course_history, if (exists("cedar_current_term")) cedar_current_term else max(course_history$term))
       dashboard_data(d)
       duration_sec <- end_report_timer(timer)
-      session$sendCustomMessage("dashboard_load_complete", list(
-        duration_sec = round(duration_sec, 1),
-        avg_sec      = if (!is.null(avg)) round(avg, 1) else NULL
-      ))
+      signal_load_complete(session, "dashboard", duration_sec = duration_sec)
     }, error = function(e) {
       tryCatch(end_report_timer(timer), error = function(e2) NULL)
+      signal_load_complete(session, "dashboard", error = TRUE)
       showNotification(paste("Dashboard error:", conditionMessage(e)), type = "error", duration = 5)
       message("[server.R] Dashboard error: ", conditionMessage(e))
     })

--- a/ui.R
+++ b/ui.R
@@ -559,87 +559,9 @@ nav_panel(
     )
   },
 
-  div(style = "position: relative; min-height: 500px;",
-
-  # Loading overlay — shown while dashboard data is computing
-  div(
-    id = "dashboard-loading-overlay",
-    class = "dash-loader-overlay",
-    style = "display: none;",
-    div(class = "dash-loader-backdrop"),
-    div(class = "dash-loader-box",
-      div(class = "dash-loader-icon",
-        div(class = "dash-spinner"),
-        tags$span("\U0001f332", class = "dash-tree-icon")
-      ),
-      div(id = "dashboard-loading-label", class = "dash-loader-msg", "Loading…"),
-      div(id = "dashboard-timing-msg",    class = "dash-timing-msg")
-    )
-  ),
-
-    tags$script(HTML(paste0('
-    (function() {
-      // expectedSec is embedded at page render time from the timing log.
-      // No async message needed — eliminates the race condition with shiny:inputchanged.
-      var expectedSec = ', {
-        avg <- get_average_report_time("dept_dashboard")
-        if (!is.null(avg)) round(avg) else 20L
-      }, ';
-      var hideTimer = null;
-
-      $(document).on("shiny:inputchanged", function(e) {
-        if (e.name !== "dashboard_dept") return;
-        if (e.value && e.value !== "") showOverlay();
-        else                            hideOverlay();
-      });
-
-      Shiny.addCustomMessageHandler("dashboard_load_complete", function(msg) {
-        completeOverlay(msg.duration_sec, msg.avg_sec);
-      });
-
-      function showOverlay() {
-        clearTimeout(hideTimer);
-        var el     = document.getElementById("dashboard-loading-overlay");
-        var label  = document.getElementById("dashboard-loading-label");
-        var timing = document.getElementById("dashboard-timing-msg");
-        if (!el) return;
-        label.textContent  = "Loading… (est. " + Math.round(expectedSec) + "s)";
-        timing.textContent = "";
-        el.style.opacity    = "0";
-        el.style.display    = "flex";
-        el.style.transition = "opacity 0.2s ease";
-        el.offsetWidth; // force reflow
-        el.style.opacity = "1";
-      }
-
-      function completeOverlay(durationSec, avgSec) {
-        var el     = document.getElementById("dashboard-loading-overlay");
-        var timing = document.getElementById("dashboard-timing-msg");
-        if (!el || el.style.display === "none") return;
-        var txt = "Loaded in " + durationSec + "s";
-        if (avgSec !== null && avgSec !== undefined) txt += " · avg " + avgSec + "s";
-        timing.textContent = txt;
-        hideTimer = setTimeout(function() {
-          el.style.transition = "opacity 0.4s ease";
-          el.style.opacity    = "0";
-          setTimeout(function() {
-            el.style.display    = "none";
-            el.style.transition = "";
-            el.style.opacity    = "1";
-          }, 400);
-        }, 800);
-      }
-
-      function hideOverlay() {
-        clearTimeout(hideTimer);
-        var el = document.getElementById("dashboard-loading-overlay");
-        if (!el) return;
-        el.style.transition = "";
-        el.style.opacity    = "1";
-        el.style.display    = "none";
-      }
-    })();
-    '))),
+  cedar_loading_overlay("dashboard", run_button = NULL,
+    trigger_input = "dashboard_dept", hide_on_empty = TRUE,
+    emoji = "\U0001f332", report_type = "dept_dashboard", fresh_default = 20,
 
     # Placeholder shown before a department is selected
     conditionalPanel(
@@ -1010,74 +932,9 @@ nav_panel(
 
     ), # end filters-compact div
 
-    div(class = "loader-anchor",
-
-      div(
-        id = "enrl-loading-overlay",
-        class = "dash-loader-overlay",
-        style = "display: none;",
-        div(class = "dash-loader-backdrop"),
-        div(class = "dash-loader-box",
-          div(class = "dash-loader-icon",
-            div(class = "dash-spinner"),
-            tags$span("\U0001f393", class = "dash-tree-icon")
-          ),
-          div(id = "enrl-loading-label", class = "dash-loader-msg", "Loading…"),
-          div(id = "enrl-timing-msg",    class = "dash-timing-msg")
-        )
-      ),
-
-      tags$script(HTML(paste0('
-      (function() {
-        var expectedSec = ', {
-          avg <- get_average_report_time("enrollment")
-          if (!is.null(avg)) round(avg) else 10L
-        }, ';
-        var hideTimer = null;
-
-        $(document).on("shiny:inputchanged", function(e) {
-          if (e.name !== "enrl_button") return;
-          showOverlay();
-        });
-
-        Shiny.addCustomMessageHandler("enrl_load_complete", function(msg) {
-          completeOverlay(msg.duration_sec, msg.avg_sec);
-        });
-
-        function showOverlay() {
-          clearTimeout(hideTimer);
-          var el    = document.getElementById("enrl-loading-overlay");
-          var label = document.getElementById("enrl-loading-label");
-          var timing = document.getElementById("enrl-timing-msg");
-          if (!el) return;
-          label.textContent  = "Loading… (est. " + Math.round(expectedSec) + "s)";
-          timing.textContent = "";
-          el.style.opacity    = "0";
-          el.style.display    = "flex";
-          el.style.transition = "opacity 0.2s ease";
-          el.offsetWidth;
-          el.style.opacity = "1";
-        }
-
-        function completeOverlay(durationSec, avgSec) {
-          var el     = document.getElementById("enrl-loading-overlay");
-          var timing = document.getElementById("enrl-timing-msg");
-          if (!el || el.style.display === "none") return;
-          var txt = "Loaded in " + durationSec + "s";
-          if (avgSec !== null && avgSec !== undefined) txt += " · avg " + avgSec + "s";
-          timing.textContent = txt;
-          hideTimer = setTimeout(function() {
-            el.style.transition = "opacity 0.4s ease";
-            el.style.opacity    = "0";
-            setTimeout(function() {
-              el.style.display    = "none";
-              el.style.transition = "";
-              el.style.opacity    = "1";
-            }, 400);
-          }, 800);
-        }
-      })();
-      '))),
+    cedar_loading_overlay("enrl", run_button = NULL,
+      trigger_input = "enrl_button",
+      emoji = "\U0001f393", report_type = "enrollment", fresh_default = 10,
 
     # Tabbed output area (shares the filter controls above)
     navset_tab(


### PR DESCRIPTION
## Goal

Finish standardizing the loading overlay. After #63, five module tabs use `cedar_loading_overlay()`, but **dashboard** and **enrollment** still carried their own hand-rolled overlay markup + JS in `ui.R` (and bespoke `sendCustomMessage` calls in `server.R`). This removes that last ad-hoc overlay code.

## Why they couldn't drop in before

Neither tab is a Shiny module, so their inputs aren't namespaced (`dashboard_dept`, `enrl_button`), and the helper triggered on a namespaced `#<id>-<run_button>` **click**. Dashboard also has no run button — it auto-runs when the department dropdown changes and hides when cleared.

## Change

**Helper generalization** (`R/modules/ui-helpers.R`):
- New optional `trigger_input` — a Shiny input name watched via `shiny:inputchanged`, as an alternative to a `run_button` click.
- New optional `hide_on_empty` — dismiss the overlay when the watched input clears to empty.
- Module callers are unchanged (`run_button` stays the positional 2nd arg); the helper errors if neither trigger is supplied.

**Conversions** (`ui.R`, `server.R`):
- Dashboard → `trigger_input = "dashboard_dept", hide_on_empty = TRUE`.
- Enrollment → `trigger_input = "enrl_button"`.
- Both now dismiss via `signal_load_complete()`; the dashboard **error** path also dismisses the overlay (previously it could linger on error).
- Per the agreed standardization, the old "· avg Ns" readout is dropped in favor of the shared "Loaded in Ns".

Net: ~150 lines of duplicated overlay/JS removed from `ui.R`; all seven tabs share one implementation.

## Verification

- All three files parse (`parse()`).
- Helper renders correctly in all three modes (module click, dashboard input-change + hide-on-empty, enrollment input-change); message channels and overlay ids preserved; guard errors with no trigger.
- Generated JS passes `node` syntax check in both modes.
- **Headless-browser behavioral test** against the real `cedar-custom.css`: simulating a `dashboard_dept` selection shows the overlay centered with the correct "(est. 20s)" estimate; clearing the department hides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)