### PR TITLE
Add waitlist trends and drilldown URL state

### DIFF
--- a/R/cones/waitlist.R
+++ b/R/cones/waitlist.R
@@ -115,6 +115,94 @@ ensure_course_title <- function(df, sections = NULL) {
 }
 
 
+#' Attach per-course enrollment context to the waitlist course overview
+#'
+#' Enriches the waitlist count table with each course's current-term enrollment,
+#' its historical average enrollment (same term type, excluding the viewed term),
+#' and the same-term-type enrollment series used to draw a sparkline in the UI.
+#' This mirrors the enrollment context shown on the regstats bumps/saturation
+#' tables so a waitlist count reads against how full the course usually runs.
+#'
+#' Enrollment history comes from the precomputed \code{cedar_cl_enrls_base} table
+#' (built in global.R) when it is in scope; outside the running app (tests, CLI)
+#' it is recomputed via \code{\link{calc_cl_enrls}}, scoped to just the courses in
+#' the overview so the fallback stays cheap.
+#'
+#' @param count_df Waitlist course-overview table (one row per campus/college/
+#'   term/part_term/subject_course) from \code{\link{get_unique_waitlisted}}.
+#' @param students Student enrollment rows, used to recompute enrollment history
+#'   when no precomputed base table is available.
+#' @return \code{count_df} with added columns \code{registered} (current-term
+#'   enrollment), \code{registered_mean} (historical average, viewed term
+#'   excluded), and the \code{trend_hist} / \code{trend_terms} list-columns the
+#'   module renders as a sparkline. Returned unchanged when no enrollment source
+#'   is available.
+#' @keywords internal
+attach_enrollment_history <- function(count_df, students) {
+  if (is.null(count_df) || nrow(count_df) == 0) return(count_df)
+
+  # Prefer the app's precomputed base; fall back to a scoped recompute so tests
+  # and CLI callers (no global base) still get enrollment context.
+  enrl_base <- if (exists("cedar_cl_enrls_base", inherits = TRUE))
+    get("cedar_cl_enrls_base", inherits = TRUE) else NULL
+
+  if (is.null(enrl_base)) {
+    scoped <- students %>% filter(subject_course %in% unique(count_df$subject_course))
+    if (nrow(scoped) == 0) return(count_df)
+    by_pt <- "part_term" %in% names(scoped)
+    # tryCatch is intentional: missing enrollment context must not sink the
+    # waitlist inspection — a failed recompute just leaves the extra columns off.
+    enrl_base <- tryCatch(
+      calc_cl_enrls(scoped, by_part_term = by_pt),
+      error = function(e) {
+        message("[waitlist.R] Skipping enrollment context: ", conditionMessage(e))
+        NULL
+      }
+    )
+    if (is.null(enrl_base)) return(count_df)
+  }
+
+  if (!all(c("registered", "term", "term_type") %in% names(enrl_base))) return(count_df)
+
+  # Match on the keys shared by both frames. part_term is included only when both
+  # carry it, so a half-term section's history isn't diluted by the full-term one.
+  match_keys <- Reduce(intersect, list(
+    c("campus", "college", "subject_course", "part_term"),
+    names(count_df), names(enrl_base)))
+
+  # Collapse the base to the overview's granularity (summing across any finer
+  # dimensions, e.g. part_term when the overview lacks it) so each course×term
+  # resolves to exactly one enrollment figure and the joins can't fan out.
+  base_agg <- enrl_base %>%
+    group_by(across(all_of(c(match_keys, "term", "term_type")))) %>%
+    summarize(registered = sum(registered, na.rm = TRUE), .groups = "drop")
+
+  # Current-term enrollment (and the row's term_type, taken from the base so it
+  # matches how the series is grouped below).
+  count_df <- count_df %>%
+    left_join(base_agg, by = c(match_keys, "term"))
+
+  # Same-term-type enrollment series (oldest→newest) for the sparkline: one list
+  # per course×term_type. Many overview rows can share a single series.
+  series <- base_agg %>%
+    arrange(term) %>%
+    group_by(across(all_of(c(match_keys, "term_type")))) %>%
+    summarize(trend_hist = list(registered), trend_terms = list(term), .groups = "drop")
+  count_df <- count_df %>%
+    left_join(series, by = c(match_keys, "term_type"))
+
+  # Historical average excludes the viewed term (matches the regstats "Hist Avg").
+  count_df$registered_mean <- mapply(function(th, tt, tm) {
+    if (is.null(th) || length(th) == 0) return(NA_real_)
+    keep <- tt != tm
+    if (!any(keep)) return(NA_real_)
+    round(mean(th[keep], na.rm = TRUE), 1)
+  }, count_df$trend_hist, count_df$trend_terms, count_df$term)
+
+  count_df
+}
+
+
 #' Inspect Waitlist by Major and Classification
 #'
 #' Comprehensive waitlist analysis that breaks down waitlisted students by their
@@ -269,6 +357,10 @@ inspect_waitlist <- function(students, opt, sections = NULL) {
         avg_size        = round(avg_size, 1)
       )
   }
+
+  # Add enrollment context (current enrollment, historical average, trend series)
+  # so each waitlist row reads against how full the course usually runs.
+  waitlist_data[["count"]] <- attach_enrollment_history(waitlist_data[["count"]], students)
 
   message("[waitlist.R] Returning waitlist data...")
 

--- a/R/modules/regstats.R
+++ b/R/modules/regstats.R
@@ -124,67 +124,10 @@ regstatsServer <- function(id, students, sections, course_flows, data_summary, t
       list(background = bg, fontWeight = if (av >= 1.0) "600" else "normal")
     }
 
-    make_sparkline <- function(values, current_idx = NULL, width = 80, height = 20,
-                               col = "#8BAF99", cur_col = "#3F5E4B") {
-      vals <- suppressWarnings(as.numeric(values))
-      vals <- vals[!is.na(vals)]
-      if (length(vals) < 2) return(htmltools::span())
-      n    <- length(vals)
-      vmin <- min(vals); vmax <- max(vals)
-      if (vmax == vmin) return(htmltools::span())
-      pad <- 2
-      xs  <- round((seq_len(n) - 1) / (n - 1) * (width - pad * 2) + pad, 1)
-      ys  <- round((1 - (vals - vmin) / (vmax - vmin)) * (height - pad * 2) + pad, 1)
-      pts <- paste(xs, ys, sep = ",", collapse = " ")
-      dot <- if (!is.null(current_idx) && current_idx >= 1 && current_idx <= n)
-        paste0('<circle cx="', xs[current_idx], '" cy="', ys[current_idx],
-               '" r="2.5" fill="', cur_col, '"/>')
-      else ""
-      htmltools::HTML(paste0(
-        '<svg width="', width, '" height="', height,
-        '" style="display:inline-block;vertical-align:middle;margin-left:4px;">',
-        '<polyline points="', pts, '" fill="none" stroke="', col,
-        '" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>',
-        dot, '</svg>'
-      ))
-    }
-
-    # ── Trend cell (shared by the saturation Fill Trend and the anomaly Trend columns) ──
-    # Linear (scaled) units-per-term slope; NA when fewer than 3 points.
-    trend_slope <- function(v, scale = 1) {
-      v <- v[!is.na(v)]
-      if (length(v) < 3) return(NA_real_)
-      round(unname(stats::coef(stats::lm(I(v * scale) ~ seq_along(v)))[2]), 1)
-    }
-    fmt_slope <- function(s, unit) if (is.na(s)) "n/a" else
-      paste0(if (s >= 0) "+" else "", formatC(s, format = "f", digits = 1), unit)
-
-    # Renders a metric's same-term-type history as a sparkline with the viewed term dotted,
-    # a ▲/▼ chip for the trend *heading into* that term, and a tooltip carrying the full-arc
-    # trend and historic average. pct = TRUE for rate metrics (fill rate 0–1, shown as
-    # points/term); FALSE for counts (enrollment, drops — shown as units/term).
-    trend_cell_html <- function(series, terms, cur_term, pct = FALSE) {
-      if (is.null(series) || length(series) < 2) return("")
-      cur   <- match(cur_term, terms)
-      scale <- if (pct) 100 else 1
-      unit  <- if (pct) " pts/term" else "/term"
-      todot <- if (!is.na(cur)) trend_slope(series[seq_len(cur)], scale) else NA_real_
-      arc   <- trend_slope(series, scale)
-      avg_v <- if (!is.na(cur) && cur > 1) mean(series[-cur], na.rm = TRUE) else mean(series, na.rm = TRUE)
-      avg_t <- if (pct) paste0(round(avg_v * 100), "%") else formatC(avg_v, format = "f", digits = 1)
-      spark <- as.character(make_sparkline(series, cur, width = 66, height = 18, cur_col = "#A15D4E"))
-      tip   <- paste0("Trend into ", cur_term, ": ", fmt_slope(todot, unit),
-                      " · full-arc: ", fmt_slope(arc, unit),
-                      " · historic avg ", avg_t, " over ", length(series), " terms")
-      chip  <- if (!is.na(todot) && abs(todot) >= 1) {
-        up <- todot > 0
-        sprintf('<span style="font-size:0.72rem;font-weight:600;margin-left:3px;color:%s">%s%s</span>',
-                if (up) "#A15D4E" else "#6F8B78", if (up) "▲" else "▼",
-                formatC(abs(todot), format = "f", digits = 1))
-      } else ""
-      sprintf('<div title="%s" style="display:flex;align-items:center;gap:2px">%s%s</div>',
-              htmltools::htmlEscape(tip, attribute = TRUE), spark, chip)
-    }
+    # make_sparkline() and trend_cell_html() (with trend_slope/fmt_slope) now live in
+    # modules/ui-helpers.R so the waitlists course overview can render the same
+    # enrollment sparkline. They're sourced before this module and used unchanged
+    # by create_regstats_reactable(), the snapshot cards, and the saturation table.
 
     create_regstats_reactable <- function(table_data) {
       if (is.null(table_data) || nrow(table_data) == 0) return(NULL)

--- a/R/modules/ui-helpers.R
+++ b/R/modules/ui-helpers.R
@@ -125,6 +125,77 @@ cedar_tbl_theme <- reactable::reactableTheme(
 )
 
 # Standardized "Part of Term" (PoT) column for cedar tables. Reuse this everywhere a
+# ── Sparkline / trend cell renderers ─────────────────────────────────────────
+# Inline SVG history sparkline and the trend-cell HTML that wraps it. Shared by
+# the regstats bumps/dips/drops/saturation tables and the waitlists course
+# overview so a course's current value reads against its own history the same way
+# everywhere. Pure (htmltools + base R only), so they render outside a Shiny
+# reactive as well.
+
+# Inline sparkline of `values` (a numeric history, ordered oldest→newest). The
+# term being viewed can be marked with a dot via current_idx. Returns an empty
+# span when there is too little variation to plot.
+make_sparkline <- function(values, current_idx = NULL, width = 80, height = 20,
+                           col = "#8BAF99", cur_col = "#3F5E4B") {
+  vals <- suppressWarnings(as.numeric(values))
+  vals <- vals[!is.na(vals)]
+  if (length(vals) < 2) return(htmltools::span())
+  n    <- length(vals)
+  vmin <- min(vals); vmax <- max(vals)
+  if (vmax == vmin) return(htmltools::span())
+  pad <- 2
+  xs  <- round((seq_len(n) - 1) / (n - 1) * (width - pad * 2) + pad, 1)
+  ys  <- round((1 - (vals - vmin) / (vmax - vmin)) * (height - pad * 2) + pad, 1)
+  pts <- paste(xs, ys, sep = ",", collapse = " ")
+  dot <- if (!is.null(current_idx) && current_idx >= 1 && current_idx <= n)
+    paste0('<circle cx="', xs[current_idx], '" cy="', ys[current_idx],
+           '" r="2.5" fill="', cur_col, '"/>')
+  else ""
+  htmltools::HTML(paste0(
+    '<svg width="', width, '" height="', height,
+    '" style="display:inline-block;vertical-align:middle;margin-left:4px;">',
+    '<polyline points="', pts, '" fill="none" stroke="', col,
+    '" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>',
+    dot, '</svg>'
+  ))
+}
+
+# Linear (scaled) units-per-term slope; NA when fewer than 3 points.
+trend_slope <- function(v, scale = 1) {
+  v <- v[!is.na(v)]
+  if (length(v) < 3) return(NA_real_)
+  round(unname(stats::coef(stats::lm(I(v * scale) ~ seq_along(v)))[2]), 1)
+}
+fmt_slope <- function(s, unit) if (is.na(s)) "n/a" else
+  paste0(if (s >= 0) "+" else "", formatC(s, format = "f", digits = 1), unit)
+
+# Renders a metric's same-term-type history as a sparkline with the viewed term dotted,
+# a ▲/▼ chip for the trend *heading into* that term, and a tooltip carrying the full-arc
+# trend and historic average. pct = TRUE for rate metrics (fill rate 0–1, shown as
+# points/term); FALSE for counts (enrollment, drops — shown as units/term).
+trend_cell_html <- function(series, terms, cur_term, pct = FALSE) {
+  if (is.null(series) || length(series) < 2) return("")
+  cur   <- match(cur_term, terms)
+  scale <- if (pct) 100 else 1
+  unit  <- if (pct) " pts/term" else "/term"
+  todot <- if (!is.na(cur)) trend_slope(series[seq_len(cur)], scale) else NA_real_
+  arc   <- trend_slope(series, scale)
+  avg_v <- if (!is.na(cur) && cur > 1) mean(series[-cur], na.rm = TRUE) else mean(series, na.rm = TRUE)
+  avg_t <- if (pct) paste0(round(avg_v * 100), "%") else formatC(avg_v, format = "f", digits = 1)
+  spark <- as.character(make_sparkline(series, cur, width = 66, height = 18, cur_col = "#A15D4E"))
+  tip   <- paste0("Trend into ", cur_term, ": ", fmt_slope(todot, unit),
+                  " · full-arc: ", fmt_slope(arc, unit),
+                  " · historic avg ", avg_t, " over ", length(series), " terms")
+  chip  <- if (!is.na(todot) && abs(todot) >= 1) {
+    up <- todot > 0
+    sprintf('<span style="font-size:0.72rem;font-weight:600;margin-left:3px;color:%s">%s%s</span>',
+            if (up) "#A15D4E" else "#6F8B78", if (up) "▲" else "▼",
+            formatC(abs(todot), format = "f", digits = 1))
+  } else ""
+  sprintf('<div title="%s" style="display:flex;align-items:center;gap:2px">%s%s</div>',
+          htmltools::htmlEscape(tip, attribute = TRUE), spark, chip)
+}
+
 # table shows part_term so the label and cell treatment stay identical across tabs.
 #   - Full-term ("1") is the common case, dimmed to "Full".
 #   - Missing/blank shows an em dash.

--- a/R/modules/waitlist.R
+++ b/R/modules/waitlist.R
@@ -190,28 +190,55 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
           showPageSizeOptions = TRUE,
           pageSizeOptions     = c(15, 30, 50),
           defaultSorted       = list(count = "desc"),
-          columns             = columns
+          # Guard against colDefs for columns a given table doesn't carry (e.g. the
+          # enrollment-context columns are only present on the count table, and only
+          # when an enrollment source was available).
+          columns             = columns[intersect(names(columns), names(data))]
         )
       }
 
       output$wl_count <- reactable::renderReactable({
         data <- wl_apply_min(waitlist_data[["count"]], wl_min()) %>% arrange(desc(count))
+
+        # Enrollment sparkline: render the per-course history list-columns (attached
+        # by inspect_waitlist) into an HTML cell via the shared trend_cell_html, then
+        # drop the list-columns so reactable can serialize the frame.
+        if (all(c("trend_hist", "trend_terms") %in% names(data))) {
+          data$enrl_trend <- vapply(seq_len(nrow(data)),
+            function(i) trend_cell_html(data$trend_hist[[i]], data$trend_terms[[i]],
+                                        data$term[i], pct = FALSE),
+            character(1))
+          data <- dplyr::select(data, -dplyr::any_of(c("trend_hist", "trend_terms")))
+        }
+
+        # Column order: identity → waitlist demand → enrollment context → supply.
+        data <- data %>%
+          dplyr::relocate(dplyr::any_of(c("registered", "registered_mean", "enrl_trend")),
+                          .after = dplyr::any_of("count"))
+
         wl_reactable(data, list(
           campus         = reactable::colDef(name = "Campus",     maxWidth = 65),
           college        = reactable::colDef(name = "College",    minWidth = 95),
-          term           = reactable::colDef(name = "Term",       maxWidth = 80),
+          # Shrunk to make room for the enrollment-context columns (Enrolled / Hist
+          # Avg / Trend); term codes are a fixed 6 chars so this stays legible.
+          term           = reactable::colDef(name = "Term",       maxWidth = 60, align = "center"),
+          term_type      = reactable::colDef(show = FALSE),
           part_term      = reactable::colDef(name = "PoT",        maxWidth = 70),
           subject_course = reactable::colDef(name = "Course",     minWidth = 90,
             cell = function(v, i) {
               htmltools::tags$a(
                 href = "javascript:void(0)",
-                onclick = sprintf("Shiny.setInputValue('waitlist-wl_navigate',{course:'%s',term:'%s'},{priority:'event'})",
+                onclick = sprintf("cedarWaitlistDrill('%s','%s')",
                                   htmltools::htmlEscape(v), htmltools::htmlEscape(term_str)),
                 htmltools::span(class = "fw-semibold", v)
               )
             }),
           course_title   = reactable::colDef(name = "Title",      minWidth = 110),
           count          = reactable::colDef(name = "Waitlisted", maxWidth = 100, align = "right"),
+          registered      = reactable::colDef(name = "Enrolled", maxWidth = 80, align = "right"),
+          registered_mean = reactable::colDef(name = "Hist Avg", maxWidth = 80, align = "right"),
+          enrl_trend      = reactable::colDef(name = "Enrollment Trend", minWidth = 108,
+            maxWidth = 150, align = "left", html = TRUE, sortable = FALSE),
           n_sections     = reactable::colDef(name = "Sections",   maxWidth = 90,  align = "right"),
           avg_size       = reactable::colDef(name = "Avg Size",   maxWidth = 90,  align = "right"),
           sections_needed = reactable::colDef(name = "Sections Needed", maxWidth = 120, align = "right")
@@ -228,7 +255,7 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
               t <- data$term[i]
               htmltools::tags$a(
                 href = "javascript:void(0)",
-                onclick = sprintf("Shiny.setInputValue('waitlist-wl_navigate',{course:'%s',term:'%s'},{priority:'event'})",
+                onclick = sprintf("cedarWaitlistDrill('%s','%s')",
                                   htmltools::htmlEscape(v), htmltools::htmlEscape(as.character(t))),
                 htmltools::span(class = "fw-semibold", v)
               )
@@ -249,7 +276,7 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
               t <- data$term[i]
               htmltools::tags$a(
                 href = "javascript:void(0)",
-                onclick = sprintf("Shiny.setInputValue('waitlist-wl_navigate',{course:'%s',term:'%s'},{priority:'event'})",
+                onclick = sprintf("cedarWaitlistDrill('%s','%s')",
                                   htmltools::htmlEscape(v), htmltools::htmlEscape(as.character(t))),
                 htmltools::span(class = "fw-semibold", v)
               )
@@ -284,6 +311,22 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
         term    = input$wl_term
       ))
       run_wl_inspection(input$wl_course, input$wl_term)
+
+      # Record this view's filters on the CURRENT history entry (replaceState, not
+      # push — clicking Inspect updates the view, it doesn't add a step). A later
+      # course drill-down pushes a new entry on top, so Back rebuilds this list.
+      # Only annotate once there's something to restore.
+      if (length(input$wl_course) > 0 || length(input$wl_term) > 0) {
+        session$sendCustomMessage("cedar_set_url", list(
+          queryStr = cedar_share_query("waitlists", list(
+            campus  = input$wl_campus, college = input$wl_college,
+            dept    = input$wl_dept,   level   = input$wl_level,
+            term    = input$wl_term,   pt      = input$wl_pt,
+            course  = input$wl_course
+          )),
+          push = FALSE
+        ))
+      }
     }, ignoreInit = TRUE)
 
     # Copy a shareable URL for the current waitlist view. Standard copy/restore
@@ -312,6 +355,9 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
       if (nzchar(course))
         parent_session$sendCustomMessage("selectize_set_value",
                                          list(id = session$ns("wl_course"), value = course))
+      else
+        # Restoring the full list (e.g. Back off a course drill-down): clear the box.
+        updateSelectizeInput(session, "wl_course", selected = character(0))
       if (nzchar(term))
         updateSelectizeInput(session, "wl_term", selected = term)
 

--- a/tests/testthat/test-waitlist.R
+++ b/tests/testthat/test-waitlist.R
@@ -199,6 +199,41 @@ test_that("inspect_waitlist course overview reports college and section supply",
   expect_equal(nurs$n_sections, 1L)           # one active NURS 2010 section in 202080
   expect_equal(nurs$avg_size, 24)             # S80010 enrolled
   expect_equal(nurs$sections_needed, 2L)      # ceiling(28 / 24)
+
+  # Enrollment-context columns are attached (values may be sparse in this
+  # waitlist-focused fixture; attach_enrollment_history has its own value test).
+  expect_true(all(c("registered", "registered_mean", "trend_hist", "trend_terms")
+                  %in% names(cnt)))
+  expect_true(is.list(cnt$trend_hist))
+})
+
+test_that("attach_enrollment_history adds current, historical, and series enrollment", {
+  message("\n  Testing attach_enrollment_history enrollment context...")
+
+  # Three fall offerings of one course: 2 → 4 → 6 registered, with a waitlist in
+  # the viewed term. RE counts as registered; WL does not.
+  mk <- function(term, n_re, n_wl = 0) {
+    tibble::tibble(
+      campus = "ABQ", college = "ARTS", term = as.integer(term),
+      subject_course = "WLST 1000", part_term = "1", term_type = "fall",
+      student_id = paste0("S", term, "_", seq_len(n_re + n_wl)),
+      registration_status_code = c(rep("RE", n_re), rep("WL", n_wl))
+    )
+  }
+  students <- dplyr::bind_rows(mk(202080, 2), mk(202180, 4), mk(202280, 6, 3))
+
+  # Course overview row for the viewed (latest) term, as get_unique_waitlisted builds it.
+  count_df <- tibble::tibble(
+    campus = "ABQ", college = "ARTS", term = 202280L, part_term = "1",
+    subject_course = "WLST 1000", course_title = "Waitlist Studies", count = 3L
+  )
+
+  res <- attach_enrollment_history(count_df, students)
+
+  expect_equal(res$registered, 6)                       # RE this term
+  expect_equal(res$registered_mean, 3)                  # mean(2, 4), viewed term excluded
+  expect_equal(res$trend_terms[[1]], c(202080L, 202180L, 202280L))
+  expect_equal(res$trend_hist[[1]], c(2, 4, 6))         # oldest → newest series
 })
 
 test_that("waitlist.R uses consistent message prefixes", {

--- a/ui.R
+++ b/ui.R
@@ -433,6 +433,46 @@ ui <- page_navbar(
           }
         });
 
+        // Update the address bar without a page load: msg = { queryStr, push }.
+        // push=true adds a history entry (Back returns to the prior view); otherwise
+        // it annotates the current entry via replaceState. Mirrors copy_cedar_url's
+        // URL shape so back-button state and copied links stay in sync.
+        Shiny.addCustomMessageHandler('cedar_set_url', function(msg) {
+          var url = window.location.pathname + '?' + msg.queryStr + window.location.hash;
+          if (msg.push) history.pushState({}, '', url);
+          else          history.replaceState({}, '', url);
+          // Remember the waitlist course/term now on screen so popstate can skip a
+          // redundant re-run when Back/Forward lands on an already-rendered view.
+          var q = new URLSearchParams(msg.queryStr);
+          if ((q.get('tab') || '') === 'waitlists') {
+            window.cedarWlRendered = {course: q.get('course') || '', term: q.get('term') || ''};
+          }
+        });
+
+        // Waitlist course drill-down (called from the table links in waitlist.R).
+        // Filters the Waitlists table by a course AND records the step in history so
+        // Back returns to the full list instead of leaving CEDAR. Only pushes an entry
+        // when already ON the Waitlists tab — cross-tab jumps (e.g. from Regstats) let
+        // the tab-switch handler's push stand so Back returns to the originating tab.
+        // The popstate handler below re-syncs the table when Back/Forward is used.
+        window.cedarWaitlistDrill = function(course, term) {
+          try {
+            var active = document.querySelector('.navbar [data-value].active, .navbar [data-value][aria-selected=true]');
+            if (active && active.getAttribute('data-value') === 'Waitlists') {
+              var cur = new URLSearchParams(window.location.search);
+              if ((cur.get('course') || '') !== course) {      // skip re-drilling the same course
+                var qs = 'tab=waitlists' + (term ? '&term=' + encodeURIComponent(term) : '')
+                       + '&course=' + encodeURIComponent(course);
+                history.pushState({tab: 'waitlists'}, '',
+                  window.location.pathname + '?' + qs + window.location.hash);
+              }
+            }
+          } catch (e) {}
+          window.cedarWlRendered = {course: course || '', term: term || ''};
+          Shiny.setInputValue('waitlist-wl_navigate',
+            {course: course || '', term: term || ''}, {priority: 'event'});
+        };
+
         // After any tab activation (manual or programmatic), close open navbar dropdowns.
         // Runs on shown.bs.tab so it fires after Bootstrap finishes its own activation sequence.
         document.addEventListener('shown.bs.tab', function() {
@@ -493,15 +533,29 @@ ui <- page_navbar(
               window.location.pathname + '?tab=' + slug + window.location.hash);
           });
 
-          // Back/Forward changed the URL → activate the matching tab without pushing.
+          // Back/Forward changed the URL → activate the matching tab without pushing,
+          // then (Waitlists only) re-sync the table to the URL's course/term so moving
+          // between the full list and a course filter also works via Back/Forward.
           window.addEventListener('popstate', function() {
-            var tabName = tabBySlug[(urlTab() || '').toLowerCase()];
+            var slug = (urlTab() || '').toLowerCase();
+            var tabName = tabBySlug[slug];
             if (!tabName) return;
             var link = document.querySelector('.navbar [data-value=\"' + tabName + '\"]');
             if (!link) return;
             suppress = true;
             link.click();
             setTimeout(function() { suppress = false; }, 500);  // backstop if shown.bs.tab never fires
+            if (slug === 'waitlists') {
+              var p = new URLSearchParams(window.location.search);
+              var course = p.get('course') || '', term = p.get('term') || '';
+              var r = window.cedarWlRendered;
+              var already = r && r.course === course && r.term === term;
+              if ((course || term) && !already) {   // annotated entry, not already shown — rebuild it
+                window.cedarWlRendered = {course: course, term: term};
+                Shiny.setInputValue('waitlist-wl_navigate',
+                  {course: course, term: term}, {priority: 'event'});
+              }
+            }
           });
         })();
       });


### PR DESCRIPTION
Enhances Waitlists with enrollment context per course by attaching current registered, historical average, and same-term-type trend series to the overview data, then rendering a sparkline trend column in the table. Shared sparkline/trend-cell renderers were moved into `ui-helpers.R` so Regstats and Waitlists use the same UI logic.

It also improves waitlist drilldown navigation by introducing URL/history syncing (push vs replace state), a shared client-side drill handler, and popstate restoration so Back/Forward correctly toggles between full-list and course-filtered views. Tests now cover enrollment-history attachment and the new waitlist output columns.