### PR TITLE
Use census enrollment in regstats and waitlists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ Reconstruct any lifecycle point from classlist status codes — all emitted by `
 - **Early drops (`DR`, `STATUS_DROP_EARLY`)** occur *before* the deadline → absent from both census and final counts (registration churn / melt).
 - **Late drops (`DG`/`DW`, `STATUS_DROP_LATE`)** occur *after* census → **counted at census, gone from the final count.** These are what make a course look *less* saturated at term end than it was at census.
 
+**Canonical census helpers (use these, don't re-derive the formula):** `add_census_enrl(df)` adds `census_enrl = registered + dr_late`; `calc_census_enrl_baselines(df, target_terms, keys)` returns the same-term-type historical mean (viewed term(s) excluded), the prior-term count, and the ordered series for a sparkline. Both live in `R/branches/enrl.R`. Enrollment comparisons across terms should flow through these so every tab measures enrollment at the census (peak) point — the regstats **bumps/dips** flags and the **Waitlists** course overview both do.
+
 **Fall 2024 magnitude (matched courses):** 10,490 early drops (never in the DESR final) and **5,531 late drops**. The late drops make census headcount ~5% higher than DESR `enrolled` (112,115 vs 107,808).
 
 ### Consequence for saturation / capacity analysis
@@ -680,6 +682,14 @@ if (!"dept_code" %in% names(df)) stop("dept_code column required but not found i
 ```
 
 This applies everywhere: cones, branches, trunk, data pipeline scripts, and test helpers. The only `tryCatch` allowed is in Shiny module servers where a caught error is immediately shown to the user via `showNotification()`.
+
+### Standardize counts and shared visuals — always prefer a helper
+
+**Before writing a count, a rate, or a visualization inline, look for an existing helper — and if one doesn't exist but the pattern shows up in more than one place, add one and route all callers through it.** Divergent local implementations of "the same thing" are how two tabs end up disagreeing about a course's enrollment or drawing subtly different sparklines.
+
+- **Ways of counting** — enrollment, drops, DFW, fill, headcount: there is (or should be) exactly one canonical definition. Census enrollment is `add_census_enrl()` / `calc_census_enrl_baselines()` (`R/branches/enrl.R`); DFW is `classify_enrollment_outcomes()` (`R/trunk/utils.R`); term type is `add_term_type_col()` / `get_term_type()`. Call these, don't re-derive `registered + dr_late` (or a grade filter, or a `substr(term, 5, 6)`) by hand. If you find the same formula written twice, that's a bug waiting to happen — extract it.
+- **Shared visualizations** — sparklines, fill bars, tier/status badges, trend cells, reactable column defs: live in `R/modules/ui-helpers.R` (`make_sparkline()`, `trend_cell_html()`, `cedar_pot_coldef()`, …). A new tab that needs a sparkline uses the shared one so every sparkline reads the same; it does not hand-roll SVG.
+- When a computation or component is currently inline and you touch nearby code, that's the moment to promote it to a helper and migrate the other callers — leave the codebase more standardized than you found it.
 
 ---
 

--- a/R/branches/enrl.R
+++ b/R/branches/enrl.R
@@ -117,6 +117,82 @@ calc_cl_enrls <- function(filtered_students, reg_status = NULL, by_part_term = F
   return (reg_stats_summary)
 }
 
+#' Add a census-point enrollment column
+#'
+#' Census enrollment is the headcount at the census snapshot: students still
+#' registered at term end (\code{registered} — RE/RS/RR) PLUS those who dropped
+#' after census (\code{dr_late} — DG/DW). Late drops were present at census but
+#' left before term end, so adding them back recovers the census headcount; early
+#' drops (DR) left before census and are excluded. This is the classlist analogue
+#' of the census basis regstats uses for saturation fill (DESR enrolled + late
+#' drops), so census enrollment lines up however it is measured.
+#'
+#' @param df A course-term enrollment table carrying \code{registered} and
+#'   \code{dr_late} (e.g. a \code{\link{calc_cl_enrls}} result or
+#'   \code{cedar_cl_enrls_base}).
+#' @return \code{df} with a \code{census_enrl} column added.
+#' @seealso \code{\link{calc_census_enrl_baselines}}
+add_census_enrl <- function(df) {
+  missing <- setdiff(c("registered", "dr_late"), names(df))
+  if (length(missing) > 0)
+    stop("[enrl.R] add_census_enrl() needs column(s): ", paste(missing, collapse = ", "))
+  df %>% mutate(census_enrl = registered + dplyr::coalesce(dr_late, 0))
+}
+
+#' Historical census-enrollment baselines per course and term type
+#'
+#' Summarizes each course's census enrollment (see \code{\link{add_census_enrl}})
+#' across its offerings into three things a "typical enrollment" readout needs:
+#' \itemize{
+#'   \item \code{census_hist} / \code{census_hist_terms} — the census series and
+#'     its terms, ordered oldest→newest and including any target term so a
+#'     sparkline can mark it in place;
+#'   \item \code{census_mean} — the mean census enrollment over PRIOR terms
+#'     (\code{target_terms} excluded so the viewed term can't inflate its own
+#'     baseline), rounded to one decimal;
+#'   \item \code{n_hist_terms} — the count of those prior terms.
+#' }
+#' Grouping is same-term-type by default so falls compare to falls; part of term is
+#' added to the grouping automatically when the data carries it. Data finer than the
+#' grouping (e.g. multiple part-of-term rows when \code{part_term} is not a key) is
+#' summed per term first so the series lists one census figure per term.
+#'
+#' @param df Course-term enrollment rows (e.g. \code{cedar_cl_enrls_base} or a
+#'   \code{\link{calc_cl_enrls}} result). Needs \code{registered}, \code{dr_late},
+#'   \code{term}, and the grouping keys.
+#' @param target_terms Term code(s) to exclude from the mean and count (the term(s)
+#'   being viewed). \code{NULL} keeps every term.
+#' @param keys Grouping columns; \code{part_term} is appended when present.
+#' @return One row per group with \code{census_mean}, \code{n_hist_terms}, and the
+#'   \code{census_hist} / \code{census_hist_terms} list-columns.
+#' @seealso \code{\link{add_census_enrl}}
+calc_census_enrl_baselines <- function(df, target_terms = NULL,
+    keys = c("campus", "college", "subject_course", "term_type")) {
+  df <- add_census_enrl(df)
+  if ("part_term" %in% names(df)) keys <- unique(c(keys, "part_term"))
+  keys <- intersect(keys, names(df))
+  target <- if (length(target_terms) > 0) unique(target_terms) else df$term[0]
+
+  df %>%
+    # Collapse to one census figure per group×term first, so callers grouping at a
+    # coarser grain than the data (e.g. no part_term) sum cleanly rather than
+    # listing duplicate term entries in the series.
+    group_by(across(all_of(c(keys, "term")))) %>%
+    summarize(census_enrl = sum(census_enrl, na.rm = TRUE), .groups = "drop") %>%
+    arrange(term) %>%
+    group_by(across(all_of(keys))) %>%
+    summarize(
+      census_hist       = list(census_enrl),
+      census_hist_terms = list(term),
+      census_mean       = {
+        h <- census_enrl[!term %in% target]
+        if (length(h) == 0) NA_real_ else round(mean(h), 1)
+      },
+      n_hist_terms      = sum(!term %in% target),
+      .groups = "drop"
+    )
+}
+
 #' Compress AOP Course Pairs
 #'
 #' Compresses paired AOP (All Online Programs) course sections into single rows.

--- a/R/cones/waitlist.R
+++ b/R/cones/waitlist.R
@@ -115,13 +115,15 @@ ensure_course_title <- function(df, sections = NULL) {
 }
 
 
-#' Attach per-course enrollment context to the waitlist course overview
+#' Attach per-course census-enrollment context to the waitlist course overview
 #'
-#' Enriches the waitlist count table with each course's current-term enrollment,
-#' its historical average enrollment (same term type, excluding the viewed term),
-#' and the same-term-type enrollment series used to draw a sparkline in the UI.
-#' This mirrors the enrollment context shown on the regstats bumps/saturation
-#' tables so a waitlist count reads against how full the course usually runs.
+#' Enriches the waitlist count table with each course's current-term census
+#' enrollment, its historical average census enrollment (same term type, viewed
+#' term excluded), the count of prior terms behind that average, and the
+#' same-term-type census series used to draw a sparkline in the UI. Census
+#' enrollment (registered + late drops; see \code{\link{add_census_enrl}}) is the
+#' comparable-across-terms basis regstats uses for saturation, so a waitlist reads
+#' against how full the course usually runs rather than against post-drop counts.
 #'
 #' Enrollment history comes from the precomputed \code{cedar_cl_enrls_base} table
 #' (built in global.R) when it is in scope; outside the running app (tests, CLI)
@@ -132,11 +134,11 @@ ensure_course_title <- function(df, sections = NULL) {
 #'   term/part_term/subject_course) from \code{\link{get_unique_waitlisted}}.
 #' @param students Student enrollment rows, used to recompute enrollment history
 #'   when no precomputed base table is available.
-#' @return \code{count_df} with added columns \code{registered} (current-term
-#'   enrollment), \code{registered_mean} (historical average, viewed term
-#'   excluded), and the \code{trend_hist} / \code{trend_terms} list-columns the
-#'   module renders as a sparkline. Returned unchanged when no enrollment source
-#'   is available.
+#' @return \code{count_df} with added columns \code{census_enrl} (current-term
+#'   census enrollment), \code{census_enrl_mean} (historical average, viewed term
+#'   excluded), \code{n_hist_terms} (prior terms behind the average), and the
+#'   \code{trend_hist} / \code{trend_terms} list-columns the module renders as a
+#'   sparkline. Returned unchanged when no enrollment source is available.
 #' @keywords internal
 attach_enrollment_history <- function(count_df, students) {
   if (is.null(count_df) || nrow(count_df) == 0) return(count_df)
@@ -162,7 +164,10 @@ attach_enrollment_history <- function(count_df, students) {
     if (is.null(enrl_base)) return(count_df)
   }
 
-  if (!all(c("registered", "term", "term_type") %in% names(enrl_base))) return(count_df)
+  if (!all(c("registered", "dr_late", "term", "term_type") %in% names(enrl_base)))
+    return(count_df)
+
+  enrl_base <- add_census_enrl(enrl_base)
 
   # Match on the keys shared by both frames. part_term is included only when both
   # carry it, so a half-term section's history isn't diluted by the full-term one.
@@ -170,34 +175,26 @@ attach_enrollment_history <- function(count_df, students) {
     c("campus", "college", "subject_course", "part_term"),
     names(count_df), names(enrl_base)))
 
-  # Collapse the base to the overview's granularity (summing across any finer
-  # dimensions, e.g. part_term when the overview lacks it) so each course×term
-  # resolves to exactly one enrollment figure and the joins can't fan out.
-  base_agg <- enrl_base %>%
+  # Current-term census enrollment (and the row's term_type, taken from the base so
+  # it matches how the baselines are grouped). Summed across any finer dimensions
+  # (e.g. part_term when the overview lacks it) so each course×term is one figure.
+  cur <- enrl_base %>%
     group_by(across(all_of(c(match_keys, "term", "term_type")))) %>%
-    summarize(registered = sum(registered, na.rm = TRUE), .groups = "drop")
-
-  # Current-term enrollment (and the row's term_type, taken from the base so it
-  # matches how the series is grouped below).
+    summarize(census_enrl = sum(census_enrl, na.rm = TRUE), .groups = "drop")
   count_df <- count_df %>%
-    left_join(base_agg, by = c(match_keys, "term"))
+    left_join(cur, by = c(match_keys, "term"))
 
-  # Same-term-type enrollment series (oldest→newest) for the sparkline: one list
-  # per course×term_type. Many overview rows can share a single series.
-  series <- base_agg %>%
-    arrange(term) %>%
-    group_by(across(all_of(c(match_keys, "term_type")))) %>%
-    summarize(trend_hist = list(registered), trend_terms = list(term), .groups = "drop")
+  # Historical census baselines: mean over prior same-term-type offerings (viewed
+  # terms excluded), prior-term count, and the full series for the sparkline. One
+  # row per course×term_type; many overview rows can share a baseline.
+  baselines <- calc_census_enrl_baselines(
+    enrl_base, target_terms = unique(count_df$term),
+    keys = c(match_keys, "term_type"))
   count_df <- count_df %>%
-    left_join(series, by = c(match_keys, "term_type"))
-
-  # Historical average excludes the viewed term (matches the regstats "Hist Avg").
-  count_df$registered_mean <- mapply(function(th, tt, tm) {
-    if (is.null(th) || length(th) == 0) return(NA_real_)
-    keep <- tt != tm
-    if (!any(keep)) return(NA_real_)
-    round(mean(th[keep], na.rm = TRUE), 1)
-  }, count_df$trend_hist, count_df$trend_terms, count_df$term)
+    left_join(baselines, by = c(match_keys, "term_type")) %>%
+    rename(census_enrl_mean = census_mean,
+           trend_hist       = census_hist,
+           trend_terms      = census_hist_terms)
 
   count_df
 }

--- a/R/modules/regstats.R
+++ b/R/modules/regstats.R
@@ -173,8 +173,8 @@ regstatsServer <- function(id, students, sections, course_flows, data_summary, t
         trend          = reactable::colDef(name = "Trend", minWidth = 108, maxWidth = 150,
           align = "left", html = TRUE),
         n_hist_terms   = reactable::colDef(name = "Hist Terms", maxWidth = 85, align = "right"),
-        registered      = reactable::colDef(name = "Enrolled",  maxWidth = 80, align = "right"),
-        registered_mean = reactable::colDef(name = "Hist Avg",  maxWidth = 80, align = "right"),
+        census_enrl      = reactable::colDef(name = "Enrolled",  maxWidth = 80, align = "right"),
+        census_enrl_mean = reactable::colDef(name = "Hist Avg",  maxWidth = 80, align = "right"),
         sd_deviation    = reactable::colDef(name = "SDs",       maxWidth = 65, align = "right",
           style = sd_style),
         impacted        = reactable::colDef(name = "Outside SD",  maxWidth = 100, align = "right",
@@ -625,9 +625,9 @@ regstatsServer <- function(id, students, sections, course_flows, data_summary, t
               tabPanel("Enrollment Bumps",
                 info_panel("About enrollment bumps",
                   tags$ul(
-                    tags$li("Courses with registration higher than their historical average for the same term type (fall vs. fall, spring vs. spring)."),
+                    tags$li("Courses with census enrollment higher than their historical average for the same term type (fall vs. fall, spring vs. spring). ", tags$strong("Enrolled"), " and ", tags$strong("Hist Avg"), " are census headcounts (registered + late drops), measured the same way for every term so drops don’t distort the comparison."),
                     tags$li("Most actionable when the course is near capacity or when Downstream Concerns shows pressure will persist."),
-                    tags$li("Column calculations (", tags$em("registered_mean"), ", ", tags$em("SDs from mean"), ", ", tags$em("Outside SD"), ") are explained in the docs."),
+                    tags$li("Column calculations (", tags$em("Hist Avg"), ", ", tags$em("SDs from mean"), ", ", tags$em("Outside SD"), ") are explained in the docs."),
                     tags$li(tags$strong("Trend"), " sparkline plots this course’s enrollment across its prior same-type offerings, with this term dotted; the ▲/▼ chip is the trend heading into it. Tells a one-term bump from a course on a rising path — hover for the full-arc trend and historic average.")
                   ),
                   tags$a("Full methodology →", href = paste0(docs, "#enrollment-bumps"), target = "_blank")
@@ -640,7 +640,7 @@ regstatsServer <- function(id, students, sections, course_flows, data_summary, t
               tabPanel("Enrollment Dips",
                 info_panel("About enrollment dips",
                   tags$ul(
-                    tags$li("Courses with registration significantly below their historical average for the same term type."),
+                    tags$li("Courses with census enrollment significantly below their historical average for the same term type. ", tags$strong("Enrolled"), " and ", tags$strong("Hist Avg"), " are census headcounts (registered + late drops), so terms compare like-for-like."),
                     tags$li("May indicate a change in student interest, competing alternatives, scheduling issues, or an instructor/format change that hasn't been widely noticed."),
                     tags$li("Column calculations follow the same pattern as Enrollment Bumps; concern tier reflects severity of the shortfall."),
                     tags$li(tags$strong("Trend"), " sparkline plots this course’s enrollment across its prior same-type offerings, with this term dotted; the ▲/▼ chip is the trend heading into it. Tells a one-term dip from a sustained decline — hover for the full-arc trend and historic average.")

--- a/R/modules/waitlist.R
+++ b/R/modules/waitlist.R
@@ -213,18 +213,19 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
 
         # Column order: identity → waitlist demand → enrollment context → supply.
         data <- data %>%
-          dplyr::relocate(dplyr::any_of(c("registered", "registered_mean", "enrl_trend")),
+          dplyr::relocate(dplyr::any_of(c("census_enrl", "census_enrl_mean",
+                                          "enrl_trend", "n_hist_terms")),
                           .after = dplyr::any_of("count"))
 
         wl_reactable(data, list(
-          campus         = reactable::colDef(name = "Campus",     maxWidth = 65),
-          college        = reactable::colDef(name = "College",    minWidth = 95),
-          # Shrunk to make room for the enrollment-context columns (Enrolled / Hist
-          # Avg / Trend); term codes are a fixed 6 chars so this stays legible.
-          term           = reactable::colDef(name = "Term",       maxWidth = 60, align = "center"),
+          campus         = reactable::colDef(name = "Campus",     maxWidth = 56, align = "center"),
+          college        = reactable::colDef(name = "College",    maxWidth = 72, align = "center"),
+          # Term/PoT and the numeric columns are trimmed so Title gets the room; term
+          # codes are a fixed 6 chars so a narrow, centered column stays legible.
+          term           = reactable::colDef(name = "Term",       maxWidth = 52, align = "center"),
           term_type      = reactable::colDef(show = FALSE),
-          part_term      = reactable::colDef(name = "PoT",        maxWidth = 70),
-          subject_course = reactable::colDef(name = "Course",     minWidth = 90,
+          part_term      = cedar_pot_coldef(),
+          subject_course = reactable::colDef(name = "Course",     minWidth = 88,
             cell = function(v, i) {
               htmltools::tags$a(
                 href = "javascript:void(0)",
@@ -233,15 +234,19 @@ waitlistServer <- function(id, students, parent_session, sections = NULL) {
                 htmltools::span(class = "fw-semibold", v)
               )
             }),
-          course_title   = reactable::colDef(name = "Title",      minWidth = 110),
-          count          = reactable::colDef(name = "Waitlisted", maxWidth = 100, align = "right"),
-          registered      = reactable::colDef(name = "Enrolled", maxWidth = 80, align = "right"),
-          registered_mean = reactable::colDef(name = "Hist Avg", maxWidth = 80, align = "right"),
-          enrl_trend      = reactable::colDef(name = "Enrollment Trend", minWidth = 108,
-            maxWidth = 150, align = "left", html = TRUE, sortable = FALSE),
-          n_sections     = reactable::colDef(name = "Sections",   maxWidth = 90,  align = "right"),
-          avg_size       = reactable::colDef(name = "Avg Size",   maxWidth = 90,  align = "right"),
-          sections_needed = reactable::colDef(name = "Sections Needed", maxWidth = 120, align = "right")
+          course_title   = reactable::colDef(name = "Title",      minWidth = 190),
+          count          = reactable::colDef(name = "Waitlisted", maxWidth = 78, align = "right"),
+          # Census enrollment (registered + late drops) — comparable across terms,
+          # the basis regstats uses for saturation.
+          census_enrl      = reactable::colDef(name = "Enrolled", maxWidth = 64, align = "right"),
+          census_enrl_mean = reactable::colDef(name = "Hist Avg", maxWidth = 68, align = "right"),
+          enrl_trend       = reactable::colDef(name = "Enrollment Trend", minWidth = 100,
+            maxWidth = 140, align = "left", html = TRUE, sortable = FALSE),
+          # Prior same-term-type offerings behind Hist Avg and the sparkline.
+          n_hist_terms     = reactable::colDef(name = "Hist Terms", maxWidth = 66, align = "right"),
+          n_sections     = reactable::colDef(name = "Sections",   maxWidth = 66,  align = "right"),
+          avg_size       = reactable::colDef(name = "Avg Size",   maxWidth = 66,  align = "right"),
+          sections_needed = reactable::colDef(name = "Sects Needed", maxWidth = 88, align = "right")
         ))
       })
 

--- a/R/reports/regstats.R
+++ b/R/reports/regstats.R
@@ -671,11 +671,29 @@ get_reg_stats <- function(students, courses, opt) {
     }
   }
 
+  # Census enrollment (registered + late drops) and its historical-only baseline,
+  # via the shared enrl.R helpers (add_census_enrl / calc_census_enrl_baselines).
+  # Bumps and dips flag on this census basis — and every anomaly table shows it as
+  # Enrolled / Hist Avg — so enrollment is compared at the census (peak) lifecycle
+  # point the same way saturation and the waitlists tab measure it. Without this the
+  # current term's pre-census live count is compared against historical POST-drop
+  # counts, which understates history and skews the flags.
+  regstats <- add_census_enrl(regstats)
+  census_bl <- calc_census_enrl_baselines(
+    regstats,
+    target_terms = if (!is.null(opt[["term"]])) convert_param_to_list(opt[["term"]]) else NULL,
+    keys = c("campus", "college", "subject_course", "term_type")
+  ) %>%
+    dplyr::select(campus, college, subject_course, term_type, part_term,
+                  census_enrl_mean = census_mean)
+  regstats <- regstats %>%
+    left_join(census_bl, by = c("campus", "college", "subject_course", "term_type", "part_term"))
+
   # find potential registration anomalies
   # use biased SD calc, since we're not really sampling from a population
   cedar_debug("[regstats.R] Finding courses of interest...")
   flagged <- list()
-  std_fields <- c("campus", "college","subject_course","part_term","term","term_type","registered")
+  std_fields <- c("campus", "college","subject_course","part_term","term","term_type","census_enrl")
   std_group_cols <- c("campus", "college","subject_course","term_type","part_term")
   #std_arrange_cols <- c("campus","term","impacted")
   std_arrange_cols <- c("campus", "college")
@@ -683,7 +701,7 @@ get_reg_stats <- function(students, courses, opt) {
   
   ##### EARLY DROPS - Fixed with proper population SD
   cedar_debug("[regstats.R] Finding early drops...")
-  drops <- regstats %>% select(all_of(std_fields), registered_mean, any_of("n_hist_terms"), drop_early=dr_early, dr_early_mean)
+  drops <- regstats %>% select(all_of(std_fields), census_enrl_mean, any_of("n_hist_terms"), drop_early=dr_early, dr_early_mean)
   drops <- drops %>% group_by(across(all_of(std_group_cols)))
   drops <- drops %>% mutate(
     # Population SD using conversion method
@@ -714,7 +732,7 @@ get_reg_stats <- function(students, courses, opt) {
 
 ##### LATE DROPS
 cedar_debug("[regstats.R] Finding late drops...")
-late_drops <- regstats %>% select(all_of(std_fields), registered_mean, any_of("n_hist_terms"), drop_late=dr_late, dr_late_mean)
+late_drops <- regstats %>% select(all_of(std_fields), census_enrl_mean, any_of("n_hist_terms"), drop_late=dr_late, dr_late_mean)
 late_drops <- late_drops %>% group_by(across(all_of(std_group_cols)))
 late_drops <- late_drops %>% mutate(
   # Population SD using direct calculation (matching early drops)
@@ -737,20 +755,20 @@ flagged[["late_drops"]] <- late_drops %>% arrange(across(all_of(std_arrange_cols
 
 ##### DIPS
 cedar_debug("[regstats.R] Finding dips...")
-dips <- regstats %>% select(all_of(std_fields), registered, registered_mean, any_of("n_hist_terms"))
+dips <- regstats %>% select(all_of(std_fields), census_enrl_mean, any_of("n_hist_terms"))
 dips <- dips %>% group_by(across(all_of(std_group_cols)))
 dips <- dips %>% mutate(
-  # Population SD using direct calculation
-  pop_sd = round(sqrt(sum((registered - registered_mean)^2) / n()), digits = 2),
-  
+  # Population SD using direct calculation (on census enrollment)
+  pop_sd = round(sqrt(sum((census_enrl - census_enrl_mean)^2) / n()), digits = 2),
+
   # Calculate deviation in SD units
-  sd_deviation = round((registered - registered_mean) / pop_sd, digits = 2),
-  
+  sd_deviation = round((census_enrl - census_enrl_mean) / pop_sd, digits = 2),
+
   # Students beyond the SD boundary: raw diff minus the expected normal variance.
-  impacted = round(registered_mean - registered - thresholds[["pct_sd"]] * pop_sd, digits=2),
+  impacted = round(census_enrl_mean - census_enrl - thresholds[["pct_sd"]] * pop_sd, digits=2),
 
   # Concern tier assignment for low anomalies
-  concern_tier = assign_concern_tier(registered, registered_mean, pop_sd, "low")
+  concern_tier = assign_concern_tier(census_enrl, census_enrl_mean, pop_sd, "low")
 )
 
 dips <- dips %>% filter(impacted > thresholds[["min_impacted"]])
@@ -761,20 +779,20 @@ flagged[["dips"]] <- dips %>% arrange(across(all_of(std_arrange_cols)))
 
 ##### BUMPS
 cedar_debug("[regstats.R] Finding bumps...")
-bumps <- regstats %>% select(all_of(std_fields), registered, registered_mean, any_of("n_hist_terms"))
+bumps <- regstats %>% select(all_of(std_fields), census_enrl_mean, any_of("n_hist_terms"))
 bumps <- bumps %>% group_by(across(all_of(std_group_cols)))
 bumps <- bumps %>% mutate(
-  # Population SD using direct calculation
-  pop_sd = round(sqrt(sum((registered - registered_mean)^2) / n()), digits = 2),
-  
+  # Population SD using direct calculation (on census enrollment)
+  pop_sd = round(sqrt(sum((census_enrl - census_enrl_mean)^2) / n()), digits = 2),
+
   # Calculate deviation in SD units
-  sd_deviation = round((registered - registered_mean) / pop_sd, digits = 2),
+  sd_deviation = round((census_enrl - census_enrl_mean) / pop_sd, digits = 2),
 
   # Students beyond the SD boundary: raw diff minus the expected normal variance.
-  impacted = round(registered - registered_mean - thresholds[["pct_sd"]] * pop_sd, digits=2),
+  impacted = round(census_enrl - census_enrl_mean - thresholds[["pct_sd"]] * pop_sd, digits=2),
 
   # Concern tier assignment for high anomalies
-  concern_tier = assign_concern_tier(registered, registered_mean, pop_sd, "high")
+  concern_tier = assign_concern_tier(census_enrl, census_enrl_mean, pop_sd, "high")
 )
 
 bumps <- bumps %>% filter(impacted > thresholds[["min_impacted"]])
@@ -993,7 +1011,7 @@ flagged[["bumps"]] <- bumps %>% arrange(across(all_of(std_arrange_cols)))
   # the module can draw a Trend sparkline — same mechanism as saturation's fill history.
   # Bumps/dips trend on enrollment; early/late drops trend on their own drop counts. This
   # is what lets a user tell a one-term blip from a developing trend.
-  trend_metric <- c(bumps = "registered", dips = "registered",
+  trend_metric <- c(bumps = "census_enrl", dips = "census_enrl",
                     early_drops = "dr_early", late_drops = "dr_late")
   for (nm in names(trend_metric)) {
     df <- flagged[[nm]]
@@ -1408,7 +1426,7 @@ get_next_term_signals <- function(flagged, students, campus = NULL) {
   # re-enroll next term. Top 20 by max impacted across drop types per course.
   drop_parts <- list()
   if (!is.null(flagged$early_drops) && nrow(flagged$early_drops) > 0L &&
-      "registered_mean" %in% names(flagged$early_drops))
+      "census_enrl_mean" %in% names(flagged$early_drops))
     drop_parts[["early"]] <- flagged$early_drops %>%
       filter(grepl("_high$", concern_tier), impacted > 0) %>%
       group_by(dplyr::across(dplyr::any_of(c("campus", "subject_course")))) %>%
@@ -1417,7 +1435,7 @@ get_next_term_signals <- function(flagged, students, campus = NULL) {
       select(any_of(c("campus", "subject_course")), impacted) %>%
       mutate(drop_type = "early drops")
   if (!is.null(flagged$late_drops) && nrow(flagged$late_drops) > 0L &&
-      "registered_mean" %in% names(flagged$late_drops))
+      "census_enrl_mean" %in% names(flagged$late_drops))
     drop_parts[["late"]] <- flagged$late_drops %>%
       filter(grepl("_high$", concern_tier), impacted > 0) %>%
       group_by(dplyr::across(dplyr::any_of(c("campus", "subject_course")))) %>%

--- a/tests/testthat/test-enrollment.R
+++ b/tests/testthat/test-enrollment.R
@@ -405,3 +405,42 @@ test_that("calc_cl_enrls with non-NULL reg_status returns only matching codes", 
   expect_true(all(result$registration_status_code == "DW"),
               info = "non-NULL reg_status should filter to only specified codes")
 })
+
+test_that("add_census_enrl sums registered and late drops", {
+  # Census headcount = still-registered + late drops (present at census); early
+  # drops happened before census and are excluded.
+  df <- tibble::tibble(
+    subject_course = c("A 100", "B 200"),
+    registered     = c(30, 10),
+    dr_early       = c(5, 0),
+    dr_late        = c(3, NA)     # NA late drops coalesce to 0
+  )
+  out <- add_census_enrl(df)
+  expect_equal(out$census_enrl, c(33, 10))
+  expect_error(add_census_enrl(tibble::tibble(registered = 1)),
+               "add_census_enrl")     # missing dr_late
+})
+
+test_that("calc_census_enrl_baselines computes historic census mean, count, and series", {
+  # One fall course over three terms; census = registered + dr_late.
+  #   202080: 2 + 1 = 3   202180: 4 + 0 = 4   202280: 6 + 2 = 8 (viewed)
+  df <- tibble::tibble(
+    campus = "ABQ", college = "ARTS", subject_course = "WLST 1000",
+    term_type = "fall", part_term = "1",
+    term       = c(202080L, 202180L, 202280L),
+    registered = c(2, 4, 6),
+    dr_late    = c(1, 0, 2)
+  )
+
+  bl <- calc_census_enrl_baselines(df, target_terms = 202280L)
+  expect_equal(nrow(bl), 1)
+  expect_equal(bl$census_mean, 3.5)                     # mean(3, 4), viewed term excluded
+  expect_equal(bl$n_hist_terms, 2L)
+  expect_equal(bl$census_hist[[1]], c(3, 4, 8))         # full series incl. viewed term
+  expect_equal(bl$census_hist_terms[[1]], c(202080L, 202180L, 202280L))
+
+  # With no target term excluded, the mean and count span every term.
+  bl_all <- calc_census_enrl_baselines(df)
+  expect_equal(bl_all$census_mean, 5)                   # mean(3, 4, 8)
+  expect_equal(bl_all$n_hist_terms, 3L)
+})

--- a/tests/testthat/test-waitlist.R
+++ b/tests/testthat/test-waitlist.R
@@ -202,25 +202,29 @@ test_that("inspect_waitlist course overview reports college and section supply",
 
   # Enrollment-context columns are attached (values may be sparse in this
   # waitlist-focused fixture; attach_enrollment_history has its own value test).
-  expect_true(all(c("registered", "registered_mean", "trend_hist", "trend_terms")
-                  %in% names(cnt)))
+  expect_true(all(c("census_enrl", "census_enrl_mean", "n_hist_terms",
+                    "trend_hist", "trend_terms") %in% names(cnt)))
   expect_true(is.list(cnt$trend_hist))
 })
 
-test_that("attach_enrollment_history adds current, historical, and series enrollment", {
-  message("\n  Testing attach_enrollment_history enrollment context...")
+test_that("attach_enrollment_history adds census enrollment context", {
+  message("\n  Testing attach_enrollment_history census enrollment context...")
 
-  # Three fall offerings of one course: 2 → 4 → 6 registered, with a waitlist in
-  # the viewed term. RE counts as registered; WL does not.
-  mk <- function(term, n_re, n_wl = 0) {
+  # Three fall offerings of one course, with late drops so census enrollment
+  # (registered + late drops) differs from the still-registered count:
+  #   202080: 2 RE + 1 DW → census 3
+  #   202180: 4 RE        → census 4
+  #   202280: 6 RE + 2 DW (+3 WL, viewed term) → census 8
+  mk <- function(term, n_re, n_wl = 0, n_dw = 0) {
     tibble::tibble(
       campus = "ABQ", college = "ARTS", term = as.integer(term),
       subject_course = "WLST 1000", part_term = "1", term_type = "fall",
-      student_id = paste0("S", term, "_", seq_len(n_re + n_wl)),
-      registration_status_code = c(rep("RE", n_re), rep("WL", n_wl))
+      student_id = paste0("S", term, "_", seq_len(n_re + n_wl + n_dw)),
+      registration_status_code = c(rep("RE", n_re), rep("WL", n_wl), rep("DW", n_dw))
     )
   }
-  students <- dplyr::bind_rows(mk(202080, 2), mk(202180, 4), mk(202280, 6, 3))
+  students <- dplyr::bind_rows(mk(202080, 2, n_dw = 1), mk(202180, 4),
+                               mk(202280, 6, n_wl = 3, n_dw = 2))
 
   # Course overview row for the viewed (latest) term, as get_unique_waitlisted builds it.
   count_df <- tibble::tibble(
@@ -230,10 +234,11 @@ test_that("attach_enrollment_history adds current, historical, and series enroll
 
   res <- attach_enrollment_history(count_df, students)
 
-  expect_equal(res$registered, 6)                       # RE this term
-  expect_equal(res$registered_mean, 3)                  # mean(2, 4), viewed term excluded
+  expect_equal(res$census_enrl, 8)                      # census this term (6 RE + 2 DW)
+  expect_equal(res$census_enrl_mean, 3.5)               # mean(3, 4), viewed term excluded
+  expect_equal(res$n_hist_terms, 2L)                    # two prior same-type terms
   expect_equal(res$trend_terms[[1]], c(202080L, 202180L, 202280L))
-  expect_equal(res$trend_hist[[1]], c(2, 4, 6))         # oldest → newest series
+  expect_equal(res$trend_hist[[1]], c(3, 4, 8))         # census series, oldest → newest
 })
 
 test_that("waitlist.R uses consistent message prefixes", {


### PR DESCRIPTION
Add shared enrollment helpers for census headcount and historical baselines, then switch regstats bumps/dips and waitlist course context to use `registered + dr_late` instead of final registered counts. This makes cross-term comparisons consistent at the census point, updates the UI/docs to match, and adds tests for the new helper behavior and waitlist enrollment context.